### PR TITLE
Styling tweaks

### DIFF
--- a/src/components/Facet.tsx
+++ b/src/components/Facet.tsx
@@ -33,7 +33,7 @@ const builtInCssClasses: FacetCssClasses = {
   optionsContainer: 'flex flex-col space-y-3',
   option: 'flex items-center space-x-3',
   optionInput: 'w-3.5 h-3.5 form-checkbox border border-gray-300 rounded-sm text-blue-600 focus:ring-blue-500',
-  optionLabel: 'text-gray-500 text-sm font-normal'
+  optionLabel: 'text-gray-600 text-sm font-normal'
 }
 
 export default function Facet(props: FacetProps): JSX.Element {

--- a/src/components/InputDropdown.tsx
+++ b/src/components/InputDropdown.tsx
@@ -1,9 +1,12 @@
+import classNames from "classnames";
 import React, { useReducer, KeyboardEvent, useRef, useEffect, useState, FocusEvent } from "react"
 import DropdownSection, { DropdownSectionProps } from "./DropdownSection";
 import ScreenReader from "./ScreenReader";
 import recursivelyMapChildren from './utils/recursivelyMapChildren';
 
 export interface InputDropdownCssClasses {
+  inputDropdownContainer?: string,
+  inputDropdownContainer___active?: string,
   dropdownContainer?: string,
   inputElement?: string,
   inputContainer?: string,
@@ -206,8 +209,13 @@ export default function InputDropdown({
     }
   }
 
+  const inputDropdownContainerCssClasses = cssClasses.inputDropdownContainer___active
+    ? classNames(cssClasses.inputDropdownContainer, 
+      { [cssClasses.inputDropdownContainer___active]: shouldDisplayDropdown })
+    : cssClasses.inputDropdownContainer;
+
   return (
-    <div ref={inputDropdownRef} onBlur={handleBlur}>
+    <div className={inputDropdownContainerCssClasses} ref={inputDropdownRef} onBlur={handleBlur}>
       <div className={cssClasses?.inputContainer}>
         <div className={cssClasses.logoContainer}>
           {renderLogo()}

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -18,16 +18,17 @@ const SCREENREADER_INSTRUCTIONS = 'When autocomplete results are available, use 
 
 export const builtInCssClasses: SearchBarCssClasses = {
   container: 'h-12',
-  divider: 'border mx-2',
+  divider: 'border-t border-gray-200 mx-2.5',
   dropdownContainer: 'relative bg-white py-1 z-10',
-  inputContainer: 'h-12 inline-flex items-center justify-between w-full',
-  inputDropdownContainer: 'bg-white shadow border rounded-3xl border-gray-300 w-full overflow-hidden',
-  inputElement: 'outline-none flex-grow border-none h-full px-2',
-  logoContainer: 'w-8 mx-2',
+  inputContainer: 'inline-flex items-center justify-between w-full',
+  inputDropdownContainer: 'bg-white border rounded-3xl border-gray-200 w-full overflow-hidden',
+  inputDropdownContainer___active: 'shadow-lg',
+  inputElement: 'outline-none flex-grow border-none h-full pl-0.5 pr-2',
+  logoContainer: 'w-7 mx-2.5 my-2',
   optionContainer: 'flex items-stretch py-1 px-2 cursor-pointer',
-  resultIconContainer: 'opacity-20 w-8 h-8 pl-1 mr-4',
-  searchButtonContainer: 'w-8 h-full mx-2',
-  submitButton: 'h-full w-full',
+  resultIconContainer: 'opacity-20 w-7 h-7 pl-1 mr-4',
+  searchButtonContainer: ' w-8 h-full mx-2 flex flex-col justify-center items-center',
+  submitButton: 'h-7 w-7',
   focusedOption: 'bg-gray-100',
   ...AutocompleteResultBuiltInCssClasses
 }
@@ -100,38 +101,36 @@ export default function SearchBar({
   }
   return (
     <div className={cssClasses.container}>
-      <div className={cssClasses.inputDropdownContainer}>
-        <InputDropdown
-          inputValue={query}
-          placeholder={placeholder}
-          screenReaderInstructions={SCREENREADER_INSTRUCTIONS}
-          screenReaderInstructionsId={screenReaderInstructionsId}
-          screenReaderText={screenReaderText}
-          onSubmit={executeQuery}
-          onInputChange={value => {
-            answersActions.setQuery(value);
-          }}
-          onInputFocus={() => {
-            autocompletePromiseRef.current = executeAutocomplete();
-          }}
-          renderLogo={() => <YextLogoIcon />}
-          renderSearchButton={renderSearchButton}
-          cssClasses={cssClasses}
-          forceHideDropdown={options.length === 0}
-        >
-          {
-            options.length > 0 &&
-            <DropdownSection
-              options={options}
-              optionIdPrefix='Autocomplete__option-0'
-              onFocusChange={value => {
-                answersActions.setQuery(value);
-              }}
-              cssClasses={cssClasses}
-            />
-          }
-        </InputDropdown>
-      </div>
+      <InputDropdown
+        inputValue={query}
+        placeholder={placeholder}
+        screenReaderInstructions={SCREENREADER_INSTRUCTIONS}
+        screenReaderInstructionsId={screenReaderInstructionsId}
+        screenReaderText={screenReaderText}
+        onSubmit={executeQuery}
+        onInputChange={value => {
+          answersActions.setQuery(value);
+        }}
+        onInputFocus={() => {
+          autocompletePromiseRef.current = executeAutocomplete();
+        }}
+        renderLogo={() => <YextLogoIcon />}
+        renderSearchButton={renderSearchButton}
+        cssClasses={cssClasses}
+        forceHideDropdown={options.length === 0}
+      >
+        {
+          options.length > 0 &&
+          <DropdownSection
+            options={options}
+            optionIdPrefix='Autocomplete__option-0'
+            onFocusChange={value => {
+              answersActions.setQuery(value);
+            }}
+            cssClasses={cssClasses}
+          />
+        }
+      </InputDropdown>
     </div>
   )
 }

--- a/src/components/StaticFilters.tsx
+++ b/src/components/StaticFilters.tsx
@@ -42,7 +42,7 @@ const builtInCssClasses: StaticFiltersCssClasses = {
   optionsContainer: 'flex flex-col space-y-3',
   option: 'flex items-center space-x-3',
   optionInput: 'w-3.5 h-3.5 form-checkbox border border-gray-300 rounded-sm text-blue-600 focus:ring-blue-500',
-  optionLabel: 'text-gray-500 text-sm font-normal'
+  optionLabel: 'text-gray-600 text-sm font-normal'
 }
 
 export default function StaticFilters(props: StaticFiltersProps): JSX.Element {

--- a/src/components/VisualAutocomplete/VisualSearchBar.tsx
+++ b/src/components/VisualAutocomplete/VisualSearchBar.tsx
@@ -206,40 +206,38 @@ export default function VisualSearchBar({
 
   return (
     <div className={cssClasses.container}>
-      <div className={cssClasses.inputDropdownContainer}>
-        <InputDropdown
-          inputValue={query}
-          placeholder={placeholder}
-          screenReaderInstructions={SCREENREADER_INSTRUCTIONS}
-          screenReaderInstructionsId={screenReaderInstructionsId}
-          screenReaderText={getScreenReaderText(autocompleteResults)}
-          onSubmit={executeQuery}
-          onInputChange={value => {
-            answersActions.setQuery(value);
-          }}
-          onInputFocus={value => {
-            updateEntityPreviews(value);
-            autocompletePromiseRef.current = executeAutocomplete();
-          }}
-          onDropdownLeave={value => {
-            updateEntityPreviews(value);
-          }}
-          renderSearchButton={() =>
-            <SearchButton
-              className={cssClasses.submitButton}
-              handleClick={executeQuery}
-              isLoading={isLoading}
-            />
-          }
-          renderLogo={() => <YextLogoIcon />}
-          cssClasses={cssClasses}
-          forceHideDropdown={autocompleteResults.length === 0 && verticalResultsArray.length === 0 && !haveRecentSearches}
-        >
-          {!hideRecentSearches && renderRecentSearches()}
-          {renderQuerySuggestions()}
-          {entityPreviews && transformEntityPreviews(entityPreviews, verticalResultsArray)}
-        </InputDropdown>
-      </div>
+      <InputDropdown
+        inputValue={query}
+        placeholder={placeholder}
+        screenReaderInstructions={SCREENREADER_INSTRUCTIONS}
+        screenReaderInstructionsId={screenReaderInstructionsId}
+        screenReaderText={getScreenReaderText(autocompleteResults)}
+        onSubmit={executeQuery}
+        onInputChange={value => {
+          answersActions.setQuery(value);
+        }}
+        onInputFocus={value => {
+          updateEntityPreviews(value);
+          autocompletePromiseRef.current = executeAutocomplete();
+        }}
+        onDropdownLeave={value => {
+          updateEntityPreviews(value);
+        }}
+        renderSearchButton={() =>
+          <SearchButton
+            className={cssClasses.submitButton}
+            handleClick={executeQuery}
+            isLoading={isLoading}
+          />
+        }
+        renderLogo={() => <YextLogoIcon />}
+        cssClasses={cssClasses}
+        forceHideDropdown={autocompleteResults.length === 0 && verticalResultsArray.length === 0 && !haveRecentSearches}
+      >
+        {!hideRecentSearches && renderRecentSearches()}
+        {renderQuerySuggestions()}
+        {entityPreviews && transformEntityPreviews(entityPreviews, verticalResultsArray)}
+      </InputDropdown>
     </div>
   )
 }

--- a/src/components/cards/StandardCard.tsx
+++ b/src/components/cards/StandardCard.tsx
@@ -24,13 +24,13 @@ export interface StandardCardCssClasses {
 }
 
 const builtInCssClasses: StandardCardCssClasses = {
-  container: 'StandardCard flex flex-col justify-between border rounded-lg mb-4 p-4',
+  container: 'StandardCard flex flex-col justify-between border rounded-lg mb-4 p-4 shadow-sm ',
   header: 'flex text-gray-800',
   body: 'flex justify-end pt-2.5',
   descriptionContainer: 'w-full text-base',
   ctaContainer: 'flex flex-col justify-end ml-4',
-  cta1: 'min-w-max bg-blue-600 text-white font-medium rounded-lg py-2 px-5',
-  cta2: 'min-w-max bg-white text-blue-600 font-medium rounded-lg py-2 px-5 mt-2 border',
+  cta1: 'min-w-max bg-blue-600 text-white font-medium rounded-lg py-2 px-5 shadow',
+  cta2: 'min-w-max bg-white text-blue-600 font-medium rounded-lg py-2 px-5 mt-2 shadow',
   ordinal: 'mr-1.5 text-lg font-medium',
   title: 'text-lg font-medium'
 }


### PR DESCRIPTION
Make some styling tweaks to bring the components closer to the mocks

There were some details which I missed on the first pass which include:
- Search bar sizing
- Search bar shadow when dropdown is open
- CTA button shadow
- Card shadow

An additional change discussed with UX is making the filter text darker

J=none
TEST=visual

Check the sizing of the mocks and the app to confirm the search bar matches the mocks