### PR TITLE
configurable options per facet

### DIFF
--- a/src/components/Facet.tsx
+++ b/src/components/Facet.tsx
@@ -5,16 +5,16 @@ import { CompositionMethod, useComposedCssClasses } from '../hooks/useComposedCs
 
 export type onFacetChangeFn = (fieldId: string, option: DisplayableFacetOption) => void
 
-export interface FacetTextConfig {
+export interface OverridableFacetConfig {
+  searchable?: boolean,
   placeholderText?: string,
-  label?: string
+  label?: string,
+  collapsible?: boolean,
+  defaultExpanded?: boolean
 }
 
-interface FacetProps extends FacetTextConfig {
+interface FacetProps extends OverridableFacetConfig {
   facet: DisplayableFacet,
-  searchable?: boolean,
-  collapsible?: boolean,
-  defaultExpanded?: boolean,
   onToggle: onFacetChangeFn,
   customCssclasses?: FacetCssClasses,
   cssCompositionMethod?: CompositionMethod
@@ -44,7 +44,7 @@ export default function Facet(props: FacetProps): JSX.Element {
     collapsible,
     defaultExpanded,
     label,
-    placeholderText,
+    placeholderText='Search here...',
     customCssclasses,
     cssCompositionMethod 
   } = props;
@@ -70,7 +70,7 @@ export default function Facet(props: FacetProps): JSX.Element {
           && <input
             className='Facet__search' 
             type='text' 
-            placeholder={placeholderText || 'Search here...'} 
+            placeholder={placeholderText} 
             value={filterValue} 
             onChange={e => setFilterValue(e.target.value)}/>}
         <div className={cssClasses.optionsContainer}>

--- a/src/components/Facet.tsx
+++ b/src/components/Facet.tsx
@@ -5,7 +5,7 @@ import { CompositionMethod, useComposedCssClasses } from '../hooks/useComposedCs
 
 export type onFacetChangeFn = (fieldId: string, option: DisplayableFacetOption) => void
 
-export interface OverridableFacetConfig {
+export interface FacetConfig {
   searchable?: boolean,
   placeholderText?: string,
   label?: string,
@@ -13,7 +13,7 @@ export interface OverridableFacetConfig {
   defaultExpanded?: boolean
 }
 
-interface FacetProps extends OverridableFacetConfig {
+interface FacetProps extends FacetConfig {
   facet: DisplayableFacet,
   onToggle: onFacetChangeFn,
   customCssclasses?: FacetCssClasses,

--- a/src/components/Facets.tsx
+++ b/src/components/Facets.tsx
@@ -1,6 +1,6 @@
 import { useAnswersState, useAnswersActions, DisplayableFacetOption } from '@yext/answers-headless-react'
 import { CompositionMethod, useComposedCssClasses } from '../hooks/useComposedCssClasses';
-import Facet, { FacetTextConfig } from './Facet';
+import Facet,{ OverridableFacetConfig } from './Facet';
 import { Divider } from './StaticFilters';
 
 
@@ -9,7 +9,7 @@ interface FacetsProps {
   searchable?: boolean,
   collapsible?: boolean,
   defaultExpanded?: boolean,
-  facetConfigs?: Record<string, FacetTextConfig>,
+  facetConfigs?: Record<string, OverridableFacetConfig>,
   customCssClasses?: FacetsCssClasses,
   cssCompositionMethod?: CompositionMethod
 }
@@ -57,15 +57,18 @@ export default function Facets (props: FacetsProps): JSX.Element {
     .filter(facet => facet.options?.length > 0)
     .map((facet, index, facetArray) => {
       const isLastFacet = index === facetArray.length -1;
-      const config = facetConfigs?.[facet.fieldId] ?? {};
+      const overrideConfig = facetConfigs?.[facet.fieldId] ?? {};
+      const config = {
+        searchable,
+        collapsible,
+        defaultExpanded,
+        ...overrideConfig
+      }
       return (
         <div key={facet.fieldId}>
           <Facet
             facet={facet}
             {...config}
-            searchable={searchable}
-            collapsible={collapsible}
-            defaultExpanded={defaultExpanded}
             onToggle={handleFacetOptionChange} />
           {!isLastFacet && <Divider customCssClasses={{ divider: cssClasses.divider }}/>}
         </div>

--- a/src/components/Facets.tsx
+++ b/src/components/Facets.tsx
@@ -1,6 +1,6 @@
 import { useAnswersState, useAnswersActions, DisplayableFacetOption } from '@yext/answers-headless-react'
 import { CompositionMethod, useComposedCssClasses } from '../hooks/useComposedCssClasses';
-import Facet,{ OverridableFacetConfig } from './Facet';
+import Facet,{ FacetConfig } from './Facet';
 import { Divider } from './StaticFilters';
 
 
@@ -9,7 +9,7 @@ interface FacetsProps {
   searchable?: boolean,
   collapsible?: boolean,
   defaultExpanded?: boolean,
-  facetConfigs?: Record<string, OverridableFacetConfig>,
+  facetConfigs?: Record<string, FacetConfig>,
   customCssClasses?: FacetsCssClasses,
   cssCompositionMethod?: CompositionMethod
 }


### PR DESCRIPTION
To match the customization level in SDK, this pr update Facets and Facet component to allow configuration of individual facet for following options: searchable, collapsible, defaultExpanded, label, and placeholderText. If not provided, Facet component will use the top-level configuration for Facets and any default value in place.

J=SLAP-1764
TEST=manual

add facetConfigs to Facets in LocationPage with different configuration combo, and see that it works as expected.