### PR TITLE
Tailwind Styling for FilterSearch and SearchableFacet

### DIFF
--- a/src/components/Facet.tsx
+++ b/src/components/Facet.tsx
@@ -20,16 +20,17 @@ interface FacetProps extends FacetConfig {
   cssCompositionMethod?: CompositionMethod
 }
 
-interface FacetCssClasses {
+export interface FacetCssClasses {
   facetLabel?: string,
   optionsContainer?: string,
   option?: string,
   optionInput?: string,
-  optionLabel?: string
+  optionLabel?: string,
+  searchableInputElement?: string
 }
 
 const builtInCssClasses: FacetCssClasses = {
-  facetLabel: 'text-gray-900 text-sm font-medium mb-4',
+  facetLabel: 'text-gray-900 font-medium mb-4',
   optionsContainer: 'flex flex-col space-y-3',
   option: 'flex items-center space-x-3',
   optionInput: 'w-3.5 h-3.5 form-checkbox border border-gray-300 rounded-sm text-blue-600 focus:ring-blue-500',
@@ -68,7 +69,7 @@ export default function Facet(props: FacetProps): JSX.Element {
       <div {...(collapsible ? getCollapseProps() : {})}>
         {searchable 
           && <input
-            className='Facet__search' 
+            className={cssClasses.searchableInputElement} 
             type='text' 
             placeholder={placeholderText} 
             value={filterValue} 

--- a/src/components/Facet.tsx
+++ b/src/components/Facet.tsx
@@ -30,7 +30,7 @@ export interface FacetCssClasses {
 }
 
 const builtInCssClasses: FacetCssClasses = {
-  facetLabel: 'text-gray-900 font-medium mb-4',
+  facetLabel: 'text-gray-900 text-sm font-medium mb-4',
   optionsContainer: 'flex flex-col space-y-3',
   option: 'flex items-center space-x-3',
   optionInput: 'w-3.5 h-3.5 form-checkbox border border-gray-300 rounded-sm text-blue-600 focus:ring-blue-500',

--- a/src/components/Facets.tsx
+++ b/src/components/Facets.tsx
@@ -22,7 +22,7 @@ interface FacetsCssClasses extends FacetCssClasses {
 }
 
 const builtInCssClasses: FacetsCssClasses = {
-  searchableInputElement: 'bg-white w-full outline-none p-1 mb-2 rounded-md border-2 border-gray-200 focus:border-blue-600',
+  searchableInputElement: 'text-sm bg-white h-9 w-full outline-none p-1 mb-2 rounded-md border border-gray-300 focus:border-blue-600',
   container: 'md:w-40',
   buttonsContainer: 'flex justify-between mt-5',
   button: 'border border-gray-300 px-2.5 py-1 rounded-md'

--- a/src/components/Facets.tsx
+++ b/src/components/Facets.tsx
@@ -1,6 +1,6 @@
 import { useAnswersState, useAnswersActions, DisplayableFacetOption } from '@yext/answers-headless-react'
 import { CompositionMethod, useComposedCssClasses } from '../hooks/useComposedCssClasses';
-import Facet,{ FacetConfig } from './Facet';
+import Facet,{ FacetConfig, FacetCssClasses } from './Facet';
 import { Divider } from './StaticFilters';
 
 
@@ -14,13 +14,18 @@ interface FacetsProps {
   cssCompositionMethod?: CompositionMethod
 }
 
-interface FacetsCssClasses {
+interface FacetsCssClasses extends FacetCssClasses {
   container?: string,
-  divider?: string
+  divider?: string,
+  buttonsContainer?: string,
+  button?: string
 }
 
 const builtInCssClasses: FacetsCssClasses = {
-  container: 'md:w-40'
+  searchableInputElement: 'bg-white w-full outline-none p-1 mb-2 rounded-md border-2 border-gray-200 focus:border-blue-600',
+  container: 'md:w-40',
+  buttonsContainer: 'flex justify-between mt-5',
+  button: 'border border-gray-300 px-2.5 py-1 rounded-md'
 }
 
 export default function Facets (props: FacetsProps): JSX.Element {
@@ -69,6 +74,7 @@ export default function Facets (props: FacetsProps): JSX.Element {
           <Facet
             facet={facet}
             {...config}
+            customCssclasses={cssClasses}
             onToggle={handleFacetOptionChange} />
           {!isLastFacet && <Divider customCssClasses={{ divider: cssClasses.divider }}/>}
         </div>
@@ -80,9 +86,9 @@ export default function Facets (props: FacetsProps): JSX.Element {
       <div>
         {facetComponents}
       </div>
-      <div>
-        {!searchOnChange && <button onClick={executeSearch}>Apply</button>}
-        <button onClick={handleResetFacets}>Reset all</button>
+      <div className={cssClasses.buttonsContainer}>
+        {!searchOnChange && <button onClick={executeSearch} className={cssClasses.button}>Apply</button>}
+        <button onClick={handleResetFacets} className={cssClasses.button}>Reset all</button>
       </div>
     </div>
   )

--- a/src/components/FilterSearch.tsx
+++ b/src/components/FilterSearch.tsx
@@ -120,11 +120,12 @@ export default function FilterSearch ({
         cssClasses={cssClasses}
       >
         {sections.map((section, sectionIndex) => {
+          const sectionId = section.label ? `${section.label}-${sectionIndex}` : `${sectionIndex}`;
           return (
             <DropdownSection
-              key={`${section.label}-${sectionIndex}`}
+              key={sectionId}
               options={section.results}
-              optionIdPrefix={`${section.label}-${sectionIndex}`}
+              optionIdPrefix={sectionId}
               onFocusChange={value => {
                 setInput(value);
               }}

--- a/src/components/FilterSearch.tsx
+++ b/src/components/FilterSearch.tsx
@@ -5,36 +5,42 @@ import DropdownSection, { DropdownSectionCssClasses, Option } from "./DropdownSe
 import { processTranslation } from "./utils/processTranslation";
 import { useSynchronizedRequest } from "../hooks/useSynchronizedRequest";
 import renderAutocompleteResult, { AutocompleteResultCssClasses } from "./utils/renderAutocompleteResult";
+import { CompositionMethod, useComposedCssClasses } from "../hooks/useComposedCssClasses";
 
 const SCREENREADER_INSTRUCTIONS = 'When autocomplete results are available, use up and down arrows to review and enter to select.'
 
-interface FilterSearchCssClasses extends InputDropdownCssClasses, DropdownSectionCssClasses, AutocompleteResultCssClasses {}
+interface FilterSearchCssClasses extends InputDropdownCssClasses, DropdownSectionCssClasses, AutocompleteResultCssClasses {
+  container?: string,
+  label?: string
+}
 
 const builtInCssClasses: FilterSearchCssClasses = {
-  dropdownContainer: 'Autocomplete',
-  inputElement: 'FilterSearch__input',
-  inputContainer: 'FilterSearch__inputContainer',
-  sectionContainer: 'Autocomplete__dropdownSection',
-  sectionLabel: 'Autocomplete__sectionLabel',
-  optionsContainer: 'Autocomplete_sectionOptions',
-  optionContainer: 'Autocomplete__option',
-  focusedOption: 'bg-gray-100'
+  container: 'mb-2',
+  label: 'mb-2 font-medium',
+  dropdownContainer: 'absolute z-10 shadow-lg rounded-md border border-gray-200 bg-white pt-3 pb-1 px-4 mt-1',
+  inputElement: 'bg-white outline-none h-full w-full p-1 rounded-md border-2 border-gray-200 focus:border-blue-600',
+  sectionContainer: 'pb-2',
+  sectionLabel: 'text-gray-700 font-semibold pb-2',
+  focusedOption: 'bg-gray-100',
+  option: 'text-gray-700 pb-1',
 }
 
 export interface FilterSearchProps {
-  title: string,
+  label: string,
   sectioned: boolean,
   searchFields: Omit<SearchParameterField, 'fetchEntities'>[],
   screenReaderInstructionsId: string,
-  customCssClasses?: FilterSearchCssClasses
+  customCssClasses?: FilterSearchCssClasses,
+  cssCompositionMethod?: CompositionMethod
 }
 
 export default function FilterSearch ({
-  title,
+  label,
   sectioned,
   searchFields,
   screenReaderInstructionsId,
-  customCssClasses
+  customCssClasses,
+  cssCompositionMethod
 }: FilterSearchProps): JSX.Element {
   const answersActions = useAnswersActions();
   const [input, setInput] = useState('');
@@ -42,7 +48,7 @@ export default function FilterSearch ({
   const searchParamFields = searchFields.map((searchField) => {
     return { ...searchField, fetchEntities: false }
   });
-  const cssClasses = { ...builtInCssClasses, ...customCssClasses };
+  const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses, cssCompositionMethod);
 
   const [filterSearchResponse, executeFilterSearch] = useSynchronizedRequest<string, FilterSearchResponse>(inputValue =>
     answersActions.executeFilterSearch(inputValue ?? '', sectioned, searchParamFields)
@@ -96,11 +102,11 @@ export default function FilterSearch ({
   }
 
   return (
-    <div className='FilterSearch'>
-      <h1>{title}</h1>
+    <div className={cssClasses.container}>
+      <h1 className={cssClasses.label}>{label}</h1>
       <InputDropdown
         inputValue={input}
-        placeholder='this is filter search...'
+        placeholder='Search here ...'
         screenReaderInstructions={SCREENREADER_INSTRUCTIONS}
         screenReaderInstructionsId={screenReaderInstructionsId}
         screenReaderText={screenReaderText}
@@ -116,9 +122,9 @@ export default function FilterSearch ({
         {sections.map((section, sectionIndex) => {
           return (
             <DropdownSection
-              key={`Autocomplete__section-${sectionIndex}`}
+              key={`${section.label}-${sectionIndex}`}
               options={section.results}
-              optionIdPrefix={`Autocomplete__option-${sectionIndex}`}
+              optionIdPrefix={`${section.label}-${sectionIndex}`}
               onFocusChange={value => {
                 setInput(value);
               }}

--- a/src/components/FilterSearch.tsx
+++ b/src/components/FilterSearch.tsx
@@ -16,13 +16,13 @@ interface FilterSearchCssClasses extends InputDropdownCssClasses, DropdownSectio
 
 const builtInCssClasses: FilterSearchCssClasses = {
   container: 'mb-2',
-  label: 'mb-2 font-medium',
-  dropdownContainer: 'absolute z-10 shadow-lg rounded-md border border-gray-200 bg-white pt-3 pb-1 px-4 mt-1',
-  inputElement: 'bg-white outline-none h-full w-full p-1 rounded-md border-2 border-gray-200 focus:border-blue-600',
+  label: 'mb-2 text-sm font-medium',
+  dropdownContainer: 'absolute z-10 shadow-lg rounded-md border border-gray-300 bg-white pt-3 pb-1 px-4 mt-1',
+  inputElement: 'text-sm bg-white outline-none h-9 w-full p-1 rounded-md border border-gray-300 focus:border-blue-600',
   sectionContainer: 'pb-2',
-  sectionLabel: 'text-gray-700 font-semibold pb-2',
+  sectionLabel: 'text-sm text-gray-700 font-semibold pb-2',
   focusedOption: 'bg-gray-100',
-  option: 'text-gray-700 pb-1',
+  option: 'text-sm text-gray-700 pb-1',
 }
 
 export interface FilterSearchProps {

--- a/src/components/InputDropdown.tsx
+++ b/src/components/InputDropdown.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React, { useReducer, KeyboardEvent, useRef, useEffect, useState, FocusEvent } from "react"
+import React, { useReducer, KeyboardEvent, useRef, useEffect, useState, FocusEvent, Children } from "react"
 import DropdownSection, { DropdownSectionProps } from "./DropdownSection";
 import ScreenReader from "./ScreenReader";
 import recursivelyMapChildren from './utils/recursivelyMapChildren';
@@ -259,7 +259,7 @@ export default function InputDropdown({
           : ''
         }
       />
-      {shouldDisplayDropdown &&
+      {shouldDisplayDropdown && Children.count(children) !== 0 &&
         <>
           <div className={cssClasses.divider}></div>
           <div className={cssClasses.dropdownContainer} ref={dropdownRef}>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -123,7 +123,7 @@ export default function SearchBar({
           options.length > 0 &&
           <DropdownSection
             options={options}
-            optionIdPrefix='Autocomplete__option-0'
+            optionIdPrefix='0'
             onFocusChange={value => {
               answersActions.setQuery(value);
             }}

--- a/src/pages/LocationsPage.tsx
+++ b/src/pages/LocationsPage.tsx
@@ -9,6 +9,7 @@ import { StandardCard } from '../components/cards/StandardCard';
 import usePageSetupEffect from '../hooks/usePageSetupEffect';
 import Facets from '../components/Facets';
 import FilterSearch from '../components/FilterSearch';
+import { Divider } from '../components/StaticFilters';
 
 const filterSearchFields = [{
   fieldApiName: 'name',
@@ -30,10 +31,11 @@ export default function LocationsPage({ verticalKey }: {
     <div className='pt-7 flex'> 
       <div>
         <FilterSearch
-          title='Filter Search!'
+          label='Filter Search'
           sectioned={true}
           searchFields={filterSearchFields}
           screenReaderInstructionsId='FilterSearchId'/>
+        <Divider />
         <Facets
           searchOnChange={true}
           searchable={true}


### PR DESCRIPTION
- add tailwindcss styling to filterSearch and searchable input element of Facet
- update InputDropdown to not show dropdown when there's no children to display

J=SLAP-1767
TEST=manual

see styling of filterSearch and Facets on Locations page match ux design given