### PR TITLE
Update AlternativeVerticals to use React Router

### DIFF
--- a/src/components/AlternativeVerticals.tsx
+++ b/src/components/AlternativeVerticals.tsx
@@ -3,6 +3,7 @@ import { ReactComponent as Star } from '../icons/star.svg';
 import { useAnswersState, useAnswersActions, VerticalResults } from '@yext/answers-headless-react';
 import { CompositionMethod, useComposedCssClasses } from '../hooks/useComposedCssClasses';
 import classNames from 'classnames';
+import { Link } from 'react-router-dom';
 
 interface AlternativeVerticalsCssClasses {
   container?: string,
@@ -138,14 +139,10 @@ export default function AlternativeVerticals ({
   function renderSuggestion(suggestion: VerticalSuggestion) {
     return (
       <li key={suggestion.verticalKey} className={cssClasses.suggestion}>
-        <button className={cssClasses.suggestionButton}
-          onClick={() => {
-            actions.setVertical(suggestion.verticalKey);
-            actions.executeVerticalQuery();
-          }}>
+        <Link className={cssClasses.suggestionButton} to={`/${suggestion.verticalKey}?query=${query}`}>
           <div className={cssClasses.verticalIcon}><Star/></div>
           <span className={cssClasses.verticalLink}>{suggestion.label}</span>
-        </button>
+        </Link>
       </li>
     );
   }
@@ -154,10 +151,9 @@ export default function AlternativeVerticals ({
     return (
       <div className={cssClasses.categoriesText}>
         <span>View results across </span>
-        <button className={cssClasses.allCategoriesLink} 
-          onClick={actions.executeUniversalQuery}>
+        <Link className={cssClasses.allCategoriesLink} to={`/?query=${query}`}>
           <span>all search categories.</span>
-        </button>
+        </Link>
       </div>
     );
   }

--- a/src/components/AlternativeVerticals.tsx
+++ b/src/components/AlternativeVerticals.tsx
@@ -1,6 +1,6 @@
 import { processTranslation } from './utils/processTranslation';
 import { ReactComponent as Star } from '../icons/star.svg';
-import { useAnswersState, useAnswersActions, VerticalResults } from '@yext/answers-headless-react';
+import { useAnswersState, VerticalResults } from '@yext/answers-headless-react';
 import { CompositionMethod, useComposedCssClasses } from '../hooks/useComposedCssClasses';
 import classNames from 'classnames';
 import { Link } from 'react-router-dom';
@@ -66,7 +66,6 @@ export default function AlternativeVerticals ({
   const alternativeVerticals = useAnswersState(state => state.vertical.noResults?.alternativeVerticals) || [];
   const allResultsForVertical = useAnswersState(state => state.vertical.noResults?.allResultsForVertical.results) || [];
   const query = useAnswersState(state => state.query.mostRecentSearch);
-  const actions = useAnswersActions();
 
   const verticalSuggestions = buildVerticalSuggestions(verticalsConfig, alternativeVerticals);
   const isShowingAllResults = displayAllResults && allResultsForVertical.length > 0;

--- a/src/components/AlternativeVerticals.tsx
+++ b/src/components/AlternativeVerticals.tsx
@@ -138,7 +138,7 @@ export default function AlternativeVerticals ({
   function renderSuggestion(suggestion: VerticalSuggestion) {
     return (
       <li key={suggestion.verticalKey} className={cssClasses.suggestion}>
-        <Link className={cssClasses.suggestionButton} to={`/${suggestion.verticalKey}?query=${query}`}>
+        <Link className={cssClasses.suggestionButton} to={`/${suggestion.verticalKey}`}>
           <div className={cssClasses.verticalIcon}><Star/></div>
           <span className={cssClasses.verticalLink}>{suggestion.label}</span>
         </Link>
@@ -150,8 +150,8 @@ export default function AlternativeVerticals ({
     return (
       <div className={cssClasses.categoriesText}>
         <span>View results across </span>
-        <Link className={cssClasses.allCategoriesLink} to={`/?query=${query}`}>
-          <span>all search categories.</span>
+        <Link className={cssClasses.allCategoriesLink} to='/'>
+          all search categories.
         </Link>
       </div>
     );


### PR DESCRIPTION
Use `Link` to update the URL and navigate to the correct universal/vertical page, instead of showing the results on the current page.

J=SLAP-1766
TEST=manual

Click on the vertical and universal links in the alternative verticals component and check that they navigate to the correct page.