### PR TITLE
Refactor display checkbox for filter/facet option

### DIFF
--- a/src/components/Facet.tsx
+++ b/src/components/Facet.tsx
@@ -84,7 +84,8 @@ export default function Facet(props: FacetProps): JSX.Element {
           {facetOptions.map(option => 
             renderCheckboxOption({
               option: { id: option.displayName, label: `${option.displayName} (${option.count})` },
-              optionHandler: () => onToggle(facet.fieldId, option)
+              optionHandler: () => onToggle(facet.fieldId, option),
+              selected: option.selected
             })
           )}
         </div>

--- a/src/components/Facet.tsx
+++ b/src/components/Facet.tsx
@@ -2,6 +2,7 @@ import { useAnswersUtilities, DisplayableFacet, DisplayableFacetOption } from '@
 import { useState } from 'react';
 import useCollapse from 'react-collapsed';
 import { CompositionMethod, useComposedCssClasses } from '../hooks/useComposedCssClasses';
+import renderCheckboxOption, { CheckboxOptionCssClasses } from './utils/renderCheckboxOption';
 
 export type onFacetChangeFn = (fieldId: string, option: DisplayableFacetOption) => void
 
@@ -20,21 +21,15 @@ interface FacetProps extends FacetConfig {
   cssCompositionMethod?: CompositionMethod
 }
 
-export interface FacetCssClasses {
+export interface FacetCssClasses extends CheckboxOptionCssClasses {
   facetLabel?: string,
   optionsContainer?: string,
-  option?: string,
-  optionInput?: string,
-  optionLabel?: string,
   searchableInputElement?: string
 }
 
 const builtInCssClasses: FacetCssClasses = {
   facetLabel: 'text-gray-900 text-sm font-medium mb-4',
   optionsContainer: 'flex flex-col space-y-3',
-  option: 'flex items-center space-x-3',
-  optionInput: 'w-3.5 h-3.5 form-checkbox border border-gray-300 rounded-sm text-blue-600 focus:ring-blue-500',
-  optionLabel: 'text-gray-600 text-sm font-normal'
 }
 
 export default function Facet(props: FacetProps): JSX.Element {
@@ -76,38 +71,13 @@ export default function Facet(props: FacetProps): JSX.Element {
             onChange={e => setFilterValue(e.target.value)}/>}
         <div className={cssClasses.optionsContainer}>
           {facetOptions.map(option => 
-            <FacetOption 
-              key={option.displayName} 
-              fieldId={facet.fieldId}
-              option={option}
-              onToggle={onToggle}
-              cssClasses={cssClasses}/>
+            renderCheckboxOption({
+              option: { id: option.displayName, label: `${option.displayName} (${option.count})` },
+              optionHandler: () => onToggle(facet.fieldId, option)
+            })
           )}
         </div>
       </div>
     </fieldset>
-  )
-}
-
-interface FacetOptionProps { 
-  fieldId: string, 
-  option: DisplayableFacetOption, 
-  onToggle: onFacetChangeFn,
-  cssClasses?: Pick<FacetCssClasses, 'option' | 'optionInput' | 'optionLabel'>
-}
-
-function FacetOption(props: FacetOptionProps): JSX.Element {
-  const { fieldId, onToggle, option, cssClasses = {} } = props;
-  return (
-    <div className={cssClasses.option}>
-      <input
-        className={cssClasses.optionInput}
-        onChange={() => onToggle(fieldId, option)}
-        checked={option.selected}
-        type='checkbox'
-        id={option.displayName}
-      />
-      <label className={cssClasses.optionLabel} htmlFor={option.displayName}>{option.displayName} ({option.count})</label>
-    </div>
   )
 }

--- a/src/components/Facet.tsx
+++ b/src/components/Facet.tsx
@@ -70,7 +70,7 @@ export default function Facet(props: FacetProps): JSX.Element {
     <fieldset>
       <button className={cssClasses.labelContainer} {...(collapsible ? getToggleProps() : {})}>
         <div className={cssClasses.label}>{label || facet.displayName}</div>
-        <DropdownIcon className={modifiedLabelIconCssClasses}/>
+        {collapsible && <DropdownIcon className={modifiedLabelIconCssClasses}/>}
       </button>
       <div {...(collapsible ? getCollapseProps() : {})}>
         {searchable 
@@ -84,7 +84,7 @@ export default function Facet(props: FacetProps): JSX.Element {
           {facetOptions.map(option => 
             renderCheckboxOption({
               option: { id: option.displayName, label: `${option.displayName} (${option.count})` },
-              optionHandler: () => onToggle(facet.fieldId, option),
+              onClick: () => onToggle(facet.fieldId, option),
               selected: option.selected
             })
           )}

--- a/src/components/Facet.tsx
+++ b/src/components/Facet.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import useCollapse from 'react-collapsed';
 import { CompositionMethod, useComposedCssClasses } from '../hooks/useComposedCssClasses';
 import renderCheckboxOption, { CheckboxOptionCssClasses } from './utils/renderCheckboxOption';
+import { ReactComponent as DropdownIcon } from '../icons/chevron.svg';
 
 export type onFacetChangeFn = (fieldId: string, option: DisplayableFacetOption) => void
 
@@ -22,13 +23,17 @@ interface FacetProps extends FacetConfig {
 }
 
 export interface FacetCssClasses extends CheckboxOptionCssClasses {
-  facetLabel?: string,
+  label?: string,
+  labelIcon?: string,
+  labelContainer?: string,
   optionsContainer?: string,
   searchableInputElement?: string
 }
 
 const builtInCssClasses: FacetCssClasses = {
-  facetLabel: 'text-gray-900 text-sm font-medium mb-4',
+  label: 'text-gray-900 text-sm font-medium',
+  labelIcon: 'w-3',
+  labelContainer: 'w-full flex justify-between items-center mb-4',
   optionsContainer: 'flex flex-col space-y-3',
 }
 
@@ -48,9 +53,14 @@ export default function Facet(props: FacetProps): JSX.Element {
   const answersUtilities = useAnswersUtilities();
   const hasSelectedFacet = !!facet.options.find(o => o.selected);
   const [ filterValue, setFilterValue ] = useState('');
-  const { getCollapseProps, getToggleProps } = useCollapse({
+  const { getCollapseProps, getToggleProps, isExpanded } = useCollapse({
     defaultExpanded: hasSelectedFacet || defaultExpanded
   });
+
+  cssClasses.labelIcon = cssClasses.labelIcon ?? '';
+  const modifiedLabelIconCssClasses = isExpanded
+    ? cssClasses.labelIcon
+    : cssClasses.labelIcon + ' transform rotate-180';
 
   const facetOptions = searchable
     ? answersUtilities.searchThroughFacet(facet, filterValue).options
@@ -58,8 +68,9 @@ export default function Facet(props: FacetProps): JSX.Element {
 
   return (
     <fieldset>
-      <button className={cssClasses.facetLabel} {...(collapsible ? getToggleProps() : {})}>
-        {label || facet.displayName} 
+      <button className={cssClasses.labelContainer} {...(collapsible ? getToggleProps() : {})}>
+        <div className={cssClasses.label}>{label || facet.displayName}</div>
+        <DropdownIcon className={modifiedLabelIconCssClasses}/>
       </button>
       <div {...(collapsible ? getCollapseProps() : {})}>
         {searchable 

--- a/src/components/StaticFilters.tsx
+++ b/src/components/StaticFilters.tsx
@@ -1,15 +1,7 @@
 import { useAnswersActions, useAnswersState, Filter, Matcher } from '@yext/answers-headless-react';
 import { CompositionMethod, useComposedCssClasses } from '../hooks/useComposedCssClasses';
 import { isDuplicateFilter } from '../utils/filterutils';
-
-interface CheckBoxProps {
-  fieldId: string,
-  value: string,
-  label: string,
-  selected: boolean,
-  optionHandler: Function,
-  cssClasses?: Pick<StaticFiltersCssClasses, 'option' | 'optionInput' | 'optionLabel'>
-}
+import renderCheckboxOption, { CheckboxOptionCssClasses } from './utils/renderCheckboxOption';
 
 interface FilterOption {
   fieldId: string,
@@ -26,23 +18,17 @@ interface StaticFiltersProps {
   cssCompositionMethod?: CompositionMethod
 }
 
-interface StaticFiltersCssClasses {
+interface StaticFiltersCssClasses extends CheckboxOptionCssClasses {
   container?: string,
   title?: string,
   optionsContainer?: string,
-  option?: string,
-  optionInput?: string,
-  optionLabel?: string,
   divider?: string
 }
 
 const builtInCssClasses: StaticFiltersCssClasses = {
   container: 'md:w-40',
   title: 'text-gray-900 text-sm font-medium mb-4',
-  optionsContainer: 'flex flex-col space-y-3',
-  option: 'flex items-center space-x-3',
-  optionInput: 'w-3.5 h-3.5 form-checkbox border border-gray-300 rounded-sm text-blue-600 focus:ring-blue-500',
-  optionLabel: 'text-gray-600 text-sm font-normal'
+  optionsContainer: 'flex flex-col space-y-3'
 }
 
 export default function StaticFilters(props: StaticFiltersProps): JSX.Element {
@@ -77,42 +63,23 @@ export default function StaticFilters(props: StaticFiltersProps): JSX.Element {
         return <fieldset key={`${index}-${filterSet.title}`}>
           <legend className={cssClasses.title}>{filterSet.title}</legend>
           <div className={cssClasses.optionsContainer}>
-            {filterSet.options.map((option, index) => (
-              <CheckboxFilter
-                fieldId={option.fieldId}
-                value={option.value}
-                label={option.label}
-                key={index}
-                selected={getOptionSelectStatus(option)}
-                optionHandler={handleFilterOptionChange}
-                cssClasses={cssClasses}
-              />
-            ))}
+            {filterSet.options.map((option, index) => {
+              const filter = {
+                fieldId: option.fieldId,
+                matcher: Matcher.Equals,
+                value: option.value
+              }
+              return renderCheckboxOption({
+                option: { id: `${index}`, label: option.label },
+                optionHandler: selected => handleFilterOptionChange(filter, selected),
+                selected: getOptionSelectStatus(option)
+              });
+            }
+            )}
           </div>
           {!isLastFilterSet && <Divider customCssClasses={{ divider: cssClasses.divider }}/>}
         </fieldset>
       })}
-    </div>
-  );
-}
-
-function CheckboxFilter({ fieldId, value, label, selected, optionHandler, cssClasses = {} }: CheckBoxProps) {
-  const filter = {
-    fieldId: fieldId,
-    matcher: Matcher.Equals,
-    value: value
-  }
-  const id = fieldId + "_" + value
-  return (
-    <div className={cssClasses.option}>
-      <input 
-        type="checkbox"
-        id={id}
-        checked={selected}
-        className={cssClasses.optionInput}
-        onChange={evt => optionHandler(filter, evt.target.checked)}
-      />
-      <label className={cssClasses.optionLabel} htmlFor={id}>{label}</label>
     </div>
   );
 }

--- a/src/components/StaticFilters.tsx
+++ b/src/components/StaticFilters.tsx
@@ -71,7 +71,7 @@ export default function StaticFilters(props: StaticFiltersProps): JSX.Element {
               }
               return renderCheckboxOption({
                 option: { id: `${index}`, label: option.label },
-                optionHandler: selected => handleFilterOptionChange(filter, selected),
+                onClick: selected => handleFilterOptionChange(filter, selected),
                 selected: getOptionSelectStatus(option)
               });
             }

--- a/src/components/utils/renderCheckboxOption.tsx
+++ b/src/components/utils/renderCheckboxOption.tsx
@@ -1,0 +1,41 @@
+interface CheckboxOption {
+  id: string,
+  label: string
+}
+
+export interface CheckboxOptionCssClasses {
+  option?: string,
+  optionLabel?: string,
+  optionInput?: string
+}
+
+interface CheckBoxOptionProps {
+  option: CheckboxOption,
+  optionHandler: (isChecked: boolean) => void,
+  selected?: boolean,
+  customCssClasses?: CheckboxOptionCssClasses
+}
+
+const builtInCssClasses: CheckboxOptionCssClasses = {
+  option: 'flex items-center space-x-3',
+  optionInput: 'w-3.5 h-3.5 form-checkbox border border-gray-300 rounded-sm text-blue-600 focus:ring-blue-500',
+  optionLabel: 'text-gray-600 text-sm font-normal'
+}
+
+export default function renderCheckboxOption({
+  option, selected, optionHandler, customCssClasses
+}: CheckBoxOptionProps) {
+  const cssClasses = { ...builtInCssClasses, ...customCssClasses };
+  return (
+    <div className={cssClasses.option} key={option.id}>
+      <input 
+        type="checkbox"
+        id={option.id}
+        checked={selected}
+        className={cssClasses.optionInput}
+        onChange={evt => optionHandler(evt.target.checked)}
+      />
+      <label className={cssClasses.optionLabel} htmlFor={option.id}>{option.label}</label>
+    </div>
+  );
+}

--- a/src/components/utils/renderCheckboxOption.tsx
+++ b/src/components/utils/renderCheckboxOption.tsx
@@ -11,7 +11,7 @@ export interface CheckboxOptionCssClasses {
 
 interface CheckBoxOptionProps {
   option: CheckboxOption,
-  optionHandler: (isChecked: boolean) => void,
+  onClick: (isChecked: boolean) => void,
   selected?: boolean,
   customCssClasses?: CheckboxOptionCssClasses
 }
@@ -23,7 +23,7 @@ const builtInCssClasses: CheckboxOptionCssClasses = {
 }
 
 export default function renderCheckboxOption({
-  option, selected, optionHandler, customCssClasses
+  option, selected, onClick, customCssClasses
 }: CheckBoxOptionProps) {
   const cssClasses = { ...builtInCssClasses, ...customCssClasses };
   return (
@@ -33,7 +33,7 @@ export default function renderCheckboxOption({
         id={option.id}
         checked={selected}
         className={cssClasses.optionInput}
-        onChange={evt => optionHandler(evt.target.checked)}
+        onChange={evt => onClick(evt.target.checked)}
       />
       <label className={cssClasses.optionLabel} htmlFor={option.id}>{option.label}</label>
     </div>

--- a/src/icons/chevron.svg
+++ b/src/icons/chevron.svg
@@ -1,5 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 7 9" >
-  <g fill-rule="evenodd" transform="translate(-1 -8)">
-    <path d="m2.6417004 8-1.1417004 1.0575 3.70850202 3.4425-3.70850202 3.4425 1.1417004 1.0575 4.8582996-4.5z"></path>
-  </g>
+<svg viewBox="0 0 12 8" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.33341 6.5L6.00008 1.83333L10.6667 6.5" stroke="#A1A1AA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/src/icons/chevron.svg
+++ b/src/icons/chevron.svg
@@ -1,3 +1,3 @@
 <svg viewBox="0 0 12 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M1.33341 6.5L6.00008 1.83333L10.6667 6.5" stroke="#A1A1AA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M1.33341 6.5L6.00008 1.83333L10.6667 6.5" stroke="#A1A1AA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>


### PR DESCRIPTION
- Created a util function renderCheckboxOption to avoid duplicate code and styling in StaticFilters and Facet(s) component.
- added dropdown icon for Facet component

J=SLAP-1773
TEST=manual

- start sample app, and see that the styling for static filters and facets stay the same. Toggle checkbox and see that it behave as expected
- toggle expand/collapse state from Facet component, see that icon's rotation update accordingly.
- when facet is not collapsible, see that dropdownIcon doesn't appear