### PR TITLE
Readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ It is intended to be forked and modified to create a custom Answers experience.
 To customize the sample site, first fork the repo from Github using the 'Fork' button on the top right of the Github page
 - Next, clone the repo with the command: `git clone https://github.com/yext/react-site-search-starter.git`
   - Note: The URL will need to be updated if you are cloning a forked site
+- Install the dependencies by running `npm i`
 - To run the app in development mode, run `npm start`
 
 ### Configuring the Search Site


### PR DESCRIPTION
Update readme to instruct an `npm i` before running `npm start`

Fixes the issue brought up here: https://hitchhikers.yext.com/community/t/installing-the-answers-headless-react-package-from-npm/3879

J=none
TEST=manual

Test that running an `npm i` fixes the issue