### PR TITLE
Checkbox pointer styling

### DIFF
--- a/src/components/utils/renderCheckboxOption.tsx
+++ b/src/components/utils/renderCheckboxOption.tsx
@@ -18,8 +18,8 @@ interface CheckBoxOptionProps {
 
 const builtInCssClasses: CheckboxOptionCssClasses = {
   option: 'flex items-center space-x-3',
-  optionInput: 'w-3.5 h-3.5 form-checkbox border border-gray-300 rounded-sm text-blue-600 focus:ring-blue-500',
-  optionLabel: 'text-gray-500 text-sm font-normal'
+  optionInput: 'w-3.5 h-3.5 form-checkbox cursor-pointer border border-gray-300 rounded-sm text-blue-600 focus:ring-blue-500',
+  optionLabel: 'text-gray-500 text-sm font-normal cursor-pointer'
 }
 
 export default function renderCheckboxOption({


### PR DESCRIPTION
Use `cursor-pointer` for checkbox options, so that the cursor becomes a pointer when hovering on the checkbox or the label of the option.

J=SLAP-1781
TEST=manual

Check that the cursor is a pointer for facet option checkboxes and labels.