### PR TITLE
Change dropdown arrow keys

### DIFF
--- a/src/components/DropdownSection.tsx
+++ b/src/components/DropdownSection.tsx
@@ -60,13 +60,13 @@ export default function DropdownSection({
   }
 
   function handleKeyDown(evt: globalThis.KeyboardEvent) {
-    if (['ArrowDown', 'ArrowUp', 'ArrowRight', 'ArrowLeft'].includes(evt.key)) {
+    if (['ArrowDown', 'ArrowUp'].includes(evt.key)) {
       evt.preventDefault();
     }
 
-    if (evt.key === 'ArrowDown' || evt.key === 'ArrowRight') {
+    if (evt.key === 'ArrowDown') {
       incrementOptionFocus();
-    } else if (evt.key === 'ArrowUp' || evt.key === 'ArrowLeft') {
+    } else if (evt.key === 'ArrowUp') {
       decrementOptionFocus();
     } else if (evt.key === 'Enter') {
       options[focusedOptionIndex].onSelect();

--- a/src/components/InputDropdown.tsx
+++ b/src/components/InputDropdown.tsx
@@ -189,8 +189,11 @@ export default function InputDropdown({
   });
 
   function handleInputElementKeydown(evt: KeyboardEvent<HTMLInputElement>) {
+    if (['ArrowDown', 'ArrowUp'].includes(evt.key)) {
+      evt.preventDefault();
+    }
+
     if (evt.key === 'Enter' 
-      && evt.target === inputRef.current
       && focusedSectionIndex === undefined
       && !onlyAllowDropdownOptionSubmissions
     ) {


### PR DESCRIPTION
- Change `DropdownSection` to only be navigable by the Up and Down arrow keys. 
    - The Right and Left arrow key behavior defaults back to being used to move within the input text.
    - Note: A separate item will address the dropdown navigation for visual autocomplete if different behavior (such as also using Right/Left for navigation) is expected. Also, wrapping behavior to loop through the dropdown options will be added after `InputDropdown` is refactored
- Change `InputDropdown` to prevent the default behavior of Up and Down arrows even when there are no dropdown options. Now, pressing Up and Down with no dropdown will have no effect (the cursor will no longer move to the very beginning or end of the input text, respectively).
- Remove unnecessary check for whether focus is on the input element in `handleInputElementKeydown`, because the function is passed directly to the input element's `onKeyDown`

J=SLAP-1736
TEST=manual

Check that arrow key interactions work as expected for SearchBar and FilterSearch.