### PR TITLE
Remove screenReaderInstructionsId prop

### DIFF
--- a/src/components/FilterSearch.tsx
+++ b/src/components/FilterSearch.tsx
@@ -108,7 +108,6 @@ export default function FilterSearch ({
         inputValue={input}
         placeholder='Search here ...'
         screenReaderInstructions={SCREENREADER_INSTRUCTIONS}
-        screenReaderInstructionsId={screenReaderInstructionsId}
         screenReaderText={screenReaderText}
         onlyAllowDropdownOptionSubmissions={true}
         onInputChange={newInput => {

--- a/src/components/InputDropdown.tsx
+++ b/src/components/InputDropdown.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React, { useReducer, KeyboardEvent, useRef, useEffect, useState, FocusEvent, Children } from "react"
+import React, { useReducer, KeyboardEvent, useRef, useEffect, useState, useMemo, FocusEvent, Children } from "react"
 import DropdownSection, { DropdownSectionProps } from "./DropdownSection";
 import ScreenReader from "./ScreenReader";
 import recursivelyMapChildren from './utils/recursivelyMapChildren';
@@ -85,7 +85,7 @@ export default function InputDropdown({
   const [latestUserInput, setLatestUserInput] = useState(inputValue);
   const [childrenKey, setChildrenKey] = useState(0);
   const [screenReaderKey, setScreenReaderKey] = useState(0);
-  const screenReaderInstructionsId = uuid();
+  const screenReaderInstructionsId = useMemo(() => uuid(), []);
 
   const inputRef = useRef<HTMLInputElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);

--- a/src/components/InputDropdown.tsx
+++ b/src/components/InputDropdown.tsx
@@ -3,6 +3,7 @@ import React, { useReducer, KeyboardEvent, useRef, useEffect, useState, FocusEve
 import DropdownSection, { DropdownSectionProps } from "./DropdownSection";
 import ScreenReader from "./ScreenReader";
 import recursivelyMapChildren from './utils/recursivelyMapChildren';
+import { v4 as uuid } from 'uuid';
 
 export interface InputDropdownCssClasses {
   inputDropdownContainer?: string,
@@ -19,7 +20,6 @@ interface Props {
   inputValue?: string,
   placeholder?: string,
   screenReaderInstructions: string,
-  screenReaderInstructionsId: string,
   screenReaderText: string,
   onlyAllowDropdownOptionSubmissions?: boolean,
   forceHideDropdown?: boolean,
@@ -60,7 +60,6 @@ export default function InputDropdown({
   inputValue = '',
   placeholder,
   screenReaderInstructions,
-  screenReaderInstructionsId,
   screenReaderText,
   onlyAllowDropdownOptionSubmissions,
   forceHideDropdown,
@@ -86,11 +85,12 @@ export default function InputDropdown({
   const [latestUserInput, setLatestUserInput] = useState(inputValue);
   const [childrenKey, setChildrenKey] = useState(0);
   const [screenReaderKey, setScreenReaderKey] = useState(0);
+  const screenReaderInstructionsId = uuid();
 
   const inputRef = useRef<HTMLInputElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const inputDropdownRef = useRef<HTMLDivElement>(null);
-  if (!shouldDisplayDropdown && screenReaderKey) {
+  if (dropdownHidden && screenReaderKey) {
     setScreenReaderKey(0);
   }
 

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -46,7 +46,6 @@ export interface SearchBarCssClasses
 interface Props {
   placeholder?: string,
   geolocationOptions?: PositionOptions,
-  screenReaderInstructionsId: string,
   customCssClasses?: SearchBarCssClasses,
   cssCompositionMethod?: CompositionMethod
 }
@@ -57,7 +56,6 @@ interface Props {
 export default function SearchBar({
   placeholder,
   geolocationOptions,
-  screenReaderInstructionsId,
   customCssClasses,
   cssCompositionMethod
 }: Props) {
@@ -104,7 +102,6 @@ export default function SearchBar({
         inputValue={query}
         placeholder={placeholder}
         screenReaderInstructions={SCREENREADER_INSTRUCTIONS}
-        screenReaderInstructionsId={screenReaderInstructionsId}
         screenReaderText={screenReaderText}
         onSubmit={executeQuery}
         onInputChange={value => {

--- a/src/components/VisualAutocomplete/VisualSearchBar.tsx
+++ b/src/components/VisualAutocomplete/VisualSearchBar.tsx
@@ -206,7 +206,6 @@ export default function VisualSearchBar({
         inputValue={query}
         placeholder={placeholder}
         screenReaderInstructions={SCREENREADER_INSTRUCTIONS}
-        screenReaderInstructionsId={screenReaderInstructionsId}
         screenReaderText={getScreenReaderText(autocompleteResults)}
         onSubmit={executeQuery}
         onInputChange={value => {

--- a/src/pages/StandardLayout.tsx
+++ b/src/pages/StandardLayout.tsx
@@ -26,7 +26,6 @@ const StandardLayout: LayoutComponent = ({ page }) => {
       {isVertical
         ? <SearchBar
           placeholder='Search...'
-          screenReaderInstructionsId='SearchBar__srInstructions'
         />
         : <SampleVisualSearchBar />
       }


### PR DESCRIPTION
Removes the `screenReaderInstructionsId` prop from `SearchBar` and `InputDropdown`. Instead, `InputDropdown` generates a UUID that is used internally and passed to `ScreenReader`.

Also, fixes a bug in `InputDropdown` that prevented some screen reader announcements from being made and sometimes caused a lag in announcements.

J=SLAP-1780
TEST=manual

Checked that screen reader instructions are still announced correctly and that announcements are now correct for `SearchBar` and `FilterSearch`.

Note: Screen reader announcements for visual autocomplete will be addressed in another item.