### PR TITLE
Rename displayAllResults to displayAllOnNoResults

### DIFF
--- a/src/components/AlternativeVerticals.tsx
+++ b/src/components/AlternativeVerticals.tsx
@@ -49,7 +49,7 @@ function isVerticalSuggestion (suggestion: VerticalSuggestion | null): suggestio
 interface Props {
   currentVerticalLabel: string,
   verticalsConfig: VerticalConfig[],
-  displayAllResults?: boolean,
+  displayAllOnNoResults?: boolean,
   customCssClasses?: AlternativeVerticalsCssClasses,
   cssCompositionMethod?: CompositionMethod
 }
@@ -57,7 +57,7 @@ interface Props {
 export default function AlternativeVerticals ({
   currentVerticalLabel,
   verticalsConfig,
-  displayAllResults = true,
+  displayAllOnNoResults = true,
   customCssClasses,
   cssCompositionMethod
 }: Props): JSX.Element | null {
@@ -68,7 +68,7 @@ export default function AlternativeVerticals ({
   const query = useAnswersState(state => state.query.mostRecentSearch);
 
   const verticalSuggestions = buildVerticalSuggestions(verticalsConfig, alternativeVerticals);
-  const isShowingAllResults = displayAllResults && allResultsForVertical.length > 0;
+  const isShowingAllResults = displayAllOnNoResults && allResultsForVertical.length > 0;
 
   const isLoading = useAnswersState(state => state.searchStatus.isLoading);
   const containerClassNames = cssClasses.alternativeVerticals___loading

--- a/src/components/VerticalResults.tsx
+++ b/src/components/VerticalResults.tsx
@@ -59,19 +59,19 @@ function renderResult(CardComponent: CardComponent, cardConfig: CardConfigTypes,
 interface VerticalResultsProps {
   CardComponent: CardComponent,
   cardConfig?: CardConfigTypes,
-  displayAllResults?: boolean,
+  displayAllOnNoResults?: boolean,
   customCssClasses?: VerticalResultsCssClasses,
   cssCompositionMethod?: CompositionMethod
 }
 
 export default function VerticalResults(props: VerticalResultsProps): JSX.Element | null {
-  const { displayAllResults = true, ...otherProps } = props;
+  const { displayAllOnNoResults = true, ...otherProps } = props;
 
   const verticalResults = useAnswersState(state => state.vertical.results) || [];
   const allResultsForVertical = useAnswersState(state => state.vertical?.noResults?.allResultsForVertical.results) || [];
   const isLoading = useAnswersState(state => state.searchStatus.isLoading);
 
-  const results = verticalResults.length === 0 && displayAllResults
+  const results = verticalResults.length === 0 && displayAllOnNoResults
     ? allResultsForVertical
     : verticalResults
 

--- a/src/pages/EventsPage.tsx
+++ b/src/pages/EventsPage.tsx
@@ -58,7 +58,6 @@ export default function EventsPage({ verticalKey }: {
         />
         <VerticalResults
           CardComponent={StandardCard}
-          displayAllResults={true}
         />
         <LocationBias />
       </div>

--- a/src/pages/FAQsPage.tsx
+++ b/src/pages/FAQsPage.tsx
@@ -35,7 +35,6 @@ export default function FAQsPage({ verticalKey }: {
       />
       <VerticalResults
         CardComponent={StandardCard}
-        displayAllResults={true}
       />
       <LocationBias />
     </div>

--- a/src/pages/JobsPage.tsx
+++ b/src/pages/JobsPage.tsx
@@ -35,7 +35,6 @@ export default function JobsPage({ verticalKey }: {
       />
       <VerticalResults
         CardComponent={StandardCard}
-        displayAllResults={true}
       />
       <LocationBias />
     </div>

--- a/src/pages/LocationsPage.tsx
+++ b/src/pages/LocationsPage.tsx
@@ -63,7 +63,6 @@ export default function LocationsPage({ verticalKey }: {
         />
         <VerticalResults
           CardComponent={StandardCard}
-          displayAllResults={true}
         />
         <LocationBias />
       </div>


### PR DESCRIPTION
Rename displayAllResults to displayAllOnNoResults to increase clarity

I also removed the `displayAllResults` props from the pages because they  default to true

J=SLAP-1779
TEST=manual

Smoke test and confirm that all results appears for no results queries