### PR TITLE
remove italic css styling for nlp filter

### DIFF
--- a/.github/workflows/wcag_test.yml
+++ b/.github/workflows/wcag_test.yml
@@ -2,7 +2,7 @@ name: WCAG tests
 
 on:
   pull_request:
-    branches: [main, hotfix/*, release/*, support/*]
+    branches: [main, develop, hotfix/*, release/*, support/*]
 
 jobs:
   WCAG-test:

--- a/src/components/AppliedFilters.tsx
+++ b/src/components/AppliedFilters.tsx
@@ -17,7 +17,7 @@ export interface AppliedFiltersCssClasses {
 const builtInCssClasses: AppliedFiltersCssClasses = {
   // Use negative margin to remove space above the filters on mobile
   appliedFiltersContainer: 'flex flex-wrap -mt-3 md:mt-0',
-  nlpFilter: 'border rounded-3xl px-3 py-1.5 text-sm font-medium italic text-gray-800 mr-2 mb-4',
+  nlpFilter: 'border rounded-3xl px-3 py-1.5 text-sm font-medium text-gray-800 mr-2 mb-4',
   removableFilter: 'flex items-center border rounded-3xl px-3 py-1.5 text-sm font-medium text-gray-900 mr-2 mb-4',
   removeFilterButton: 'w-2 h-2 text-gray-500 m-1.5'
 }


### PR DESCRIPTION
remove italic for nlp filter

J=SLAP-1797
TEST=manual

see that nlp filter is no longer in italic