### PR TITLE
Applied filters update once results load

### DIFF
--- a/.github/workflows/wcag_test.yml
+++ b/.github/workflows/wcag_test.yml
@@ -2,7 +2,7 @@ name: WCAG tests
 
 on:
   pull_request:
-    branches: [main, hotfix/*, release/*, support/*]
+    branches: [main, develop, hotfix/*, release/*, support/*]
 
 jobs:
   WCAG-test:

--- a/.github/workflows/wcag_test.yml
+++ b/.github/workflows/wcag_test.yml
@@ -2,7 +2,7 @@ name: WCAG tests
 
 on:
   pull_request:
-    branches: [main, develop, hotfix/*, release/*, support/*]
+    branches: [main, hotfix/*, release/*, support/*]
 
 jobs:
   WCAG-test:

--- a/src/components/AlternativeVerticals.tsx
+++ b/src/components/AlternativeVerticals.tsx
@@ -71,9 +71,9 @@ export default function AlternativeVerticals ({
   const isShowingAllResults = displayAllOnNoResults && allResultsForVertical.length > 0;
 
   const isLoading = useAnswersState(state => state.searchStatus.isLoading);
-  const containerClassNames = cssClasses.alternativeVerticals___loading
-    ? classNames(cssClasses.container, { [cssClasses.alternativeVerticals___loading]: isLoading })
-    : cssClasses.container;
+  const containerClassNames = classNames(cssClasses.container, {
+    [cssClasses.alternativeVerticals___loading ?? '']: isLoading
+  });
 
   function buildVerticalSuggestions(
     verticalsConfig: VerticalConfig[],

--- a/src/components/AppliedFilters.tsx
+++ b/src/components/AppliedFilters.tsx
@@ -31,8 +31,7 @@ interface AppliedFiltersDisplayProps {
   labelText?: string,
   delimiter?: string,
   displayableFilters: DisplayableFilter[],
-  customCssClasses?: AppliedFiltersCssClasses,
-  cssCompositionMethod?: CompositionMethod
+  cssClasses?: AppliedFiltersCssClasses
 }
 
 export interface AppliedFiltersProps {
@@ -57,20 +56,22 @@ export default function AppliedFilters (
     filterState.current = state.vertical.results ? state.filters : {};
   }
 
-  const { hiddenFields = [], staticFiltersGroupLabels = {}, ...otherProps } = props;
+  const { hiddenFields = [], staticFiltersGroupLabels = {}, customCssClasses = {}, cssCompositionMethod, ...otherProps } = props;
   const groupedFilters: Array<GroupedFilters> = getGroupedAppliedFilters(filterState.current, nlpFilters, hiddenFields, staticFiltersGroupLabels);
   const appliedFilters = groupedFilters.flatMap(groupedFilters => groupedFilters.filters);
-  return <AppliedFiltersDisplay displayableFilters={appliedFilters} {...otherProps}/>
+
+  const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses, cssCompositionMethod);
+  cssClasses.appliedFiltersContainer = classNames(cssClasses.appliedFiltersContainer, {
+    [cssClasses.appliedFiltersContainer___loading ?? '']: state.searchStatus.isLoading
+  });
+  return <AppliedFiltersDisplay displayableFilters={appliedFilters} cssClasses={cssClasses} {...otherProps}/>
 };
 
 export function AppliedFiltersDisplay ({
   labelText,
   displayableFilters,
-  customCssClasses = {},
-  cssCompositionMethod
+  cssClasses = {}
 }: AppliedFiltersDisplayProps): JSX.Element {
-  const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses, cssCompositionMethod);
-  const isLoading = useAnswersState(state => state.searchStatus.isLoading);
 
   function NlpFilter({ filter }: { filter: DisplayableFilter }): JSX.Element {
     return (
@@ -108,16 +109,10 @@ export function AppliedFiltersDisplay ({
     );
   }
 
-  const containerClassNames = cssClasses.appliedFiltersContainer___loading
-    ? classNames(cssClasses.appliedFiltersContainer, {
-      [ cssClasses.appliedFiltersContainer___loading ]: isLoading
-    })
-    : cssClasses.appliedFiltersContainer;
-
   return (
     <>
       { displayableFilters.length > 0 &&
-        <div className={containerClassNames} aria-label={labelText}>
+        <div className={cssClasses.appliedFiltersContainer} aria-label={labelText}>
           {displayableFilters.map((filter: DisplayableFilter) => {
             const key = `${filter.filterType}-${filter.label}`;
             if (filter.filterType === 'NLP_FILTER') {

--- a/src/components/AppliedFilters.tsx
+++ b/src/components/AppliedFilters.tsx
@@ -17,7 +17,7 @@ export interface AppliedFiltersCssClasses {
 const builtInCssClasses: AppliedFiltersCssClasses = {
   // Use negative margin to remove space above the filters on mobile
   appliedFiltersContainer: 'flex flex-wrap -mt-3 md:mt-0',
-  nlpFilter: 'border rounded-3xl px-3 py-1.5 text-sm font-medium italic text-gray-800 mr-2 mb-4',
+  nlpFilter: 'border rounded-3xl px-3 py-1.5 text-sm font-medium text-gray-800 mr-2 mb-4',
   removableFilter: 'flex items-center border rounded-3xl px-3 py-1.5 text-sm font-medium text-gray-900 mr-2 mb-4',
   removeFilterButton: 'w-2 h-2 text-gray-500 m-1.5'
 }

--- a/src/components/AppliedFilters.tsx
+++ b/src/components/AppliedFilters.tsx
@@ -49,11 +49,14 @@ export interface AppliedFiltersProps {
 export default function AppliedFilters (
   props : AppliedFiltersProps
 ): JSX.Element {
-  const nlpFilters = useAnswersState(state => state.vertical?.appliedQueryFilters) || [];
-  const state = useAnswersState(state => state);
+  const nlpFilters = useAnswersState(state => state.vertical.appliedQueryFilters) || [];
+  const isLoading = useAnswersState(state => state.searchStatus.isLoading);
+  const verticalResults = useAnswersState(state => state.vertical.results);
+  const filters = useAnswersState(state => state.filters);
+
   const filterState = useRef<FiltersState>({});
-  if (!state.searchStatus.isLoading) {
-    filterState.current = state.vertical.results ? state.filters : {};
+  if (!isLoading) {
+    filterState.current = verticalResults ? filters : {};
   }
 
   const { hiddenFields = [], staticFiltersGroupLabels = {}, customCssClasses = {}, cssCompositionMethod, ...otherProps } = props;
@@ -62,7 +65,7 @@ export default function AppliedFilters (
 
   const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses, cssCompositionMethod);
   cssClasses.appliedFiltersContainer = classNames(cssClasses.appliedFiltersContainer, {
-    [cssClasses.appliedFiltersContainer___loading ?? '']: state.searchStatus.isLoading
+    [cssClasses.appliedFiltersContainer___loading ?? '']: isLoading
   });
   return <AppliedFiltersDisplay displayableFilters={appliedFilters} cssClasses={cssClasses} {...otherProps}/>
 };

--- a/src/components/AppliedFilters.tsx
+++ b/src/components/AppliedFilters.tsx
@@ -21,7 +21,7 @@ const builtInCssClasses: AppliedFiltersCssClasses = {
   // Use negative margin to remove space above the filters on mobile
   appliedFiltersContainer: 'flex flex-wrap -mt-3 md:mt-0',
   appliedFiltersContainer___loading: 'opacity-50',
-  nlpFilter: 'border rounded-3xl px-3 py-1.5 text-sm font-medium text-gray-800 mr-2 mb-4',
+  nlpFilter: 'border rounded-3xl px-3 py-1.5 text-sm font-medium italic text-gray-800 mr-2 mb-4',
   removableFilter: 'flex items-center border rounded-3xl px-3 py-1.5 text-sm font-medium text-gray-900 mr-2 mb-4',
   removeFilterButton: 'w-2 h-2 text-gray-500 m-1.5'
 }

--- a/src/components/DirectAnswer.tsx
+++ b/src/components/DirectAnswer.tsx
@@ -68,9 +68,9 @@ export default function DirectAnswer(props: DirectAnswerProps): JSX.Element | nu
     </>
   }
 
-  const containerCssClasses = cssClasses.container___loading
-    ? classNames(cssClasses.container, { [cssClasses.container___loading ]: isLoading })
-    : cssClasses.container;
+  const containerCssClasses = classNames(cssClasses.container, {
+    [cssClasses.container___loading ?? '']: isLoading
+  });
 
   return (
     <div className={containerCssClasses}>

--- a/src/components/DropdownSection.tsx
+++ b/src/components/DropdownSection.tsx
@@ -88,11 +88,9 @@ export default function DropdownSection({
   });
 
   function renderOption(option: Option, index: number) {
-    const optionContainterCssClasses = cssClasses.focusedOption
-      ? classNames(cssClasses.optionContainer, {
-        [cssClasses.focusedOption]: isFocused && index === focusedOptionIndex
-      })
-      : cssClasses.optionContainer;
+    const optionContainterCssClasses = classNames(cssClasses.optionContainer, {
+      [cssClasses.focusedOption ?? '']: isFocused && index === focusedOptionIndex
+    });
     return (
       <div
         key={index}

--- a/src/components/InputDropdown.tsx
+++ b/src/components/InputDropdown.tsx
@@ -212,10 +212,9 @@ export default function InputDropdown({
     }
   }
 
-  const inputDropdownContainerCssClasses = cssClasses.inputDropdownContainer___active
-    ? classNames(cssClasses.inputDropdownContainer, 
-      { [cssClasses.inputDropdownContainer___active]: shouldDisplayDropdown })
-    : cssClasses.inputDropdownContainer;
+  const inputDropdownContainerCssClasses = classNames(cssClasses.inputDropdownContainer, {
+    [cssClasses.inputDropdownContainer___active ?? '']: shouldDisplayDropdown
+  });
 
   return (
     <div className={inputDropdownContainerCssClasses} ref={inputDropdownRef} onBlur={handleBlur}>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -138,9 +138,9 @@ function renderLink(
   cssClasses: { navLinkContainer?: string, navLinkContainer___active?: string, navLink?: string }) 
 {
   const { to, label } = linkData;
-  const navLinkContainerClasses = cssClasses.navLinkContainer___active 
-    ? classNames(cssClasses.navLinkContainer, { [cssClasses.navLinkContainer___active]: isActiveLink }) 
-    : cssClasses.navLinkContainer;
+  const navLinkContainerClasses = classNames(cssClasses.navLinkContainer, {
+    [cssClasses.navLinkContainer___active ?? '']: isActiveLink
+  });
   return (
     <div className={navLinkContainerClasses} key={to}>
       <NavLink

--- a/src/components/ResultsCount.tsx
+++ b/src/components/ResultsCount.tsx
@@ -61,9 +61,9 @@ export function ResultsCountDisplay({
   const spanArray = messageArray.map((value, index) => {
     const isNumber = typeof value === 'number';
     
-    const classes = cssClasses.number
-      ? classNames(cssClasses.text, { [cssClasses.number]: isNumber })
-      : cssClasses.text ?? '';
+    const classes = classNames(cssClasses.text, {
+      [cssClasses.number ?? '']: isNumber
+    });
 
     return <span key={`${index}-${value}`} className={classes}>{value}</span>
   });

--- a/src/components/SpellCheck.tsx
+++ b/src/components/SpellCheck.tsx
@@ -26,9 +26,9 @@ export default function SpellCheck ({ customCssClasses, cssCompositionMethod }: 
   const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses, cssCompositionMethod);
   const correctedQuery = useAnswersState(state => state.spellCheck.correctedQuery);
   const isLoading = useAnswersState(state => state.searchStatus.isLoading);
-  const containerClassNames = cssClasses.spellCheck___loading
-    ? classNames(cssClasses.container, { [cssClasses.spellCheck___loading]: isLoading })
-    : cssClasses.container;
+  const containerClassNames = classNames(cssClasses.container, {
+    [cssClasses.spellCheck___loading ?? '']: isLoading
+  });
   const answersActions = useAnswersActions();
   if (!correctedQuery) {
     return null;

--- a/src/components/UniversalResults.tsx
+++ b/src/components/UniversalResults.tsx
@@ -44,7 +44,7 @@ export default function UniversalResults({
   customCssClasses,
   cssCompositionMethod
 }: UniversalResultsProps): JSX.Element | null {
-  const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses, cssCompositionMethod)
+  const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses, cssCompositionMethod);
   const resultsFromAllVerticals = useAnswersState(state => state?.universal?.verticals) || [];
   const isLoading = useAnswersState(state => state.searchStatus.isLoading);
 
@@ -52,9 +52,9 @@ export default function UniversalResults({
     return null;
   }
 
-  const resultsClassNames = cssClasses.results___loading
-    ? classNames(cssClasses.container, { [cssClasses.results___loading]: isLoading })
-    : cssClasses.container;
+  const resultsClassNames = classNames(cssClasses.container, {
+    [cssClasses.results___loading ?? '']: isLoading
+  });
 
   return (
     <div className={resultsClassNames}>

--- a/src/components/VerticalResults.tsx
+++ b/src/components/VerticalResults.tsx
@@ -35,9 +35,9 @@ export function VerticalResultsDisplay(props: VerticalResultsDisplayProps): JSX.
     return null;
   }
 
-  const resultsClassNames = cssClasses.results___loading
-    ? classNames({ [cssClasses.results___loading]: isLoading })
-    : '';
+  const resultsClassNames = classNames({
+    [cssClasses.results___loading ?? '']: isLoading
+  });
 
   return (
     <div className={resultsClassNames}>

--- a/src/sections/SectionHeader.tsx
+++ b/src/sections/SectionHeader.tsx
@@ -22,7 +22,7 @@ const builtInCssClasses: SectionHeaderCssClasses = {
   viewMoreContainer: 'flex justify-end flex-grow ml-auto font-medium text-gray-800',
   viewMoreLink: 'text-blue-600 pr-1 pl-3',
   appliedFiltersContainer: 'ml-3 flex flex-wrap',
-  nlpFilter: 'border rounded-3xl px-3 py-1.5 text-sm font-medium text-gray-800 mr-2',
+  nlpFilter: 'border rounded-3xl px-3 py-1.5 text-sm font-medium italic text-gray-800 mr-2',
   removableFilter: 'flex items-center border rounded-3xl px-3 py-1.5 text-sm font-medium text-gray-900 mr-2',
   removeFilterButton: 'w-2 h-2 text-gray-500 m-1.5'
 }

--- a/src/sections/SectionHeader.tsx
+++ b/src/sections/SectionHeader.tsx
@@ -22,7 +22,7 @@ const builtInCssClasses: SectionHeaderCssClasses = {
   viewMoreContainer: 'flex justify-end flex-grow ml-auto font-medium text-gray-800',
   viewMoreLink: 'text-blue-600 pr-1 pl-3',
   appliedFiltersContainer: 'ml-3 flex flex-wrap',
-  nlpFilter: 'border rounded-3xl px-3 py-1.5 text-sm font-medium italic text-gray-800 mr-2',
+  nlpFilter: 'border rounded-3xl px-3 py-1.5 text-sm font-medium text-gray-800 mr-2',
   removableFilter: 'flex items-center border rounded-3xl px-3 py-1.5 text-sm font-medium text-gray-900 mr-2',
   removeFilterButton: 'w-2 h-2 text-gray-500 m-1.5'
 }

--- a/src/sections/SectionHeader.tsx
+++ b/src/sections/SectionHeader.tsx
@@ -5,14 +5,14 @@ import { useComposedCssClasses, CompositionMethod } from "../hooks/useComposedCs
 import { ReactComponent as CollectionIcon } from '../icons/collection.svg';
 import { useAnswersState } from '@yext/answers-headless-react';
 import { DisplayableFilter } from "../models/displayableFilter";
+import classNames from "classnames";
 
 interface SectionHeaderCssClasses extends AppliedFiltersCssClasses {
   sectionHeaderContainer?: string,
   sectionHeaderIconContainer?: string,
   sectionHeaderLabel?: string,
   viewMoreContainer?: string,
-  viewMoreLink?: string,
-  appliedFiltersContainer?: string
+  viewMoreLink?: string
 }
 
 const builtInCssClasses: SectionHeaderCssClasses = {
@@ -39,7 +39,7 @@ interface SectionHeaderConfig {
 
 export default function SectionHeader(props: SectionHeaderConfig): JSX.Element {
   const { label, verticalKey, viewAllButton = false, appliedFiltersConfig, customCssClasses, cssCompositionMethod } = props;
-  const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses, cssCompositionMethod)
+  const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses, cssCompositionMethod);
   const latestQuery = useAnswersState(state => state.query.mostRecentSearch); 
   const displayableFilters = appliedFiltersConfig?.appliedQueryFilters?.map((appliedQueryFilter): DisplayableFilter => {
     return {
@@ -49,6 +49,11 @@ export default function SectionHeader(props: SectionHeaderConfig): JSX.Element {
       label: appliedQueryFilter.displayValue
     }
   }) ?? [];
+
+  const isLoading = useAnswersState(state => state.searchStatus.isLoading);
+  cssClasses.appliedFiltersContainer = classNames(cssClasses.appliedFiltersContainer, {
+    [cssClasses.appliedFiltersContainer___loading ?? '']: isLoading
+  });
 
   return (
     <div className={cssClasses.sectionHeaderContainer}>
@@ -60,7 +65,7 @@ export default function SectionHeader(props: SectionHeaderConfig): JSX.Element {
         {resultsCountConfig &&
            <ResultsCountDisplay resultsLength={resultsCountConfig.resultsLength} resultsCount={resultsCountConfig.resultsCount} />} */}
       {appliedFiltersConfig &&
-        <AppliedFiltersDisplay displayableFilters={displayableFilters} customCssClasses={cssClasses} cssCompositionMethod='replace'/>
+        <AppliedFiltersDisplay displayableFilters={displayableFilters} cssClasses={cssClasses}/>
       }
       {viewAllButton && 
         <div className={cssClasses.viewMoreContainer}>

--- a/tests/appliedFilters.test.tsx
+++ b/tests/appliedFilters.test.tsx
@@ -57,8 +57,9 @@ describe('AppliedFilters component works as expected', () => {
     expect(filerRemoveButton).toBeTruthy();
 
     filerRemoveButton.click();
+    await act( async () => { await answers.executeVerticalQuery() });
     filterLabels = container.getElementsByClassName(cssClasses.filterLabel);
-    setTimeout(() => expect(filterLabels.length).toBe(0), 1000);
+    expect(filterLabels.length).toBe(0);
   });
 
   it('A selected facet appears and is removable', async () => {
@@ -95,8 +96,9 @@ describe('AppliedFilters component works as expected', () => {
     expect(filerRemoveButton).toBeTruthy();
 
     filerRemoveButton.click();
+    await act( async () => { await answers.executeVerticalQuery() });
     facetLabels = container.getElementsByClassName(cssClasses.filterLabel);
-    setTimeout(() => expect(facetLabels.length).toBe(0), 1000);
+    expect(facetLabels.length).toBe(0);
   });
 
   it('NLP filters appear and are not removable', async () => {

--- a/tests/appliedFilters.test.tsx
+++ b/tests/appliedFilters.test.tsx
@@ -13,6 +13,7 @@ const cssClasses: Required<AppliedFiltersCssClasses> = {
   filterLabel: 'filterLabel',
   removeFilterButton: 'removeFilterButton',
   appliedFiltersContainer: '',
+  appliedFiltersContainer___loading: '',
   nlpFilter: '',
   removableFilter: ''
 };
@@ -57,7 +58,7 @@ describe('AppliedFilters component works as expected', () => {
 
     filerRemoveButton.click();
     filterLabels = container.getElementsByClassName(cssClasses.filterLabel);
-    expect(filterLabels.length).toBe(0);
+    setTimeout(() => expect(filterLabels.length).toBe(0), 1000);
   });
 
   it('A selected facet appears and is removable', async () => {
@@ -95,7 +96,7 @@ describe('AppliedFilters component works as expected', () => {
 
     filerRemoveButton.click();
     facetLabels = container.getElementsByClassName(cssClasses.filterLabel);
-    expect(facetLabels.length).toBe(0);
+    setTimeout(() => expect(facetLabels.length).toBe(0), 1000);
   });
 
   it('NLP filters appear and are not removable', async () => {


### PR DESCRIPTION
Only update applied filters once the results have finished loading. Also, change opacity of applied filters when loading.

J=SLAP-1796
TEST=manual

Check that applied filters have the correct behavior on Locations and Events pages.