### PR TITLE
Include recent searches option in screen reader

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -79,7 +79,7 @@ export default function SearchBar({
         answersActions.setQuery(result.value);
         executeQuery();
       },
-      display: renderAutocompleteResult(result, cssClasses, MagnifyingGlassIcon)
+      display: renderAutocompleteResult(result, cssClasses, MagnifyingGlassIcon, `autocomplete option: ${result.value}`)
     }
   }) ?? [];
 

--- a/src/components/VisualAutocomplete/VisualSearchBar.tsx
+++ b/src/components/VisualAutocomplete/VisualSearchBar.tsx
@@ -1,4 +1,4 @@
-import { useAnswersActions, useAnswersState, useAnswersUtilities, VerticalResults, AutocompleteResult } from '@yext/answers-headless-react';
+import { useAnswersActions, useAnswersState, useAnswersUtilities, VerticalResults } from '@yext/answers-headless-react';
 import { PropsWithChildren, useEffect, useState } from 'react';
 import InputDropdown from '../InputDropdown';
 import '../../sass/Autocomplete.scss';
@@ -129,7 +129,12 @@ export default function VisualSearchBar({
           answersActions.setQuery(result.value);
           executeQuery();
         },
-        display: renderAutocompleteResult(result, cssClasses, MagnifyingGlassIcon)
+        display: renderAutocompleteResult(
+          result,
+          cssClasses,
+          MagnifyingGlassIcon,
+          `autocomplete option: ${result.value}`
+        )
       });
 
       if (hideVerticalLinks) {
@@ -183,7 +188,12 @@ export default function VisualSearchBar({
           answersActions.setQuery(result.query);
           executeQuery();
         },
-        display: renderAutocompleteResult({ value: result.query }, recentSearchesCssClasses, RecentSearchIcon)
+        display: renderAutocompleteResult(
+          { value: result.query },
+          recentSearchesCssClasses,
+          RecentSearchIcon,
+          `recent search option: ${result.query}`
+        )
       }
     }) ?? [];
     if (options.length === 0) {
@@ -207,7 +217,7 @@ export default function VisualSearchBar({
         inputValue={query}
         placeholder={placeholder}
         screenReaderInstructions={SCREENREADER_INSTRUCTIONS}
-        screenReaderText={getScreenReaderText(autocompleteResults)}
+        screenReaderText={getScreenReaderText(autocompleteResults.length , filteredRecentSearches?.length || 0)}
         onSubmit={executeQuery}
         onInputChange={value => {
           answersActions.setQuery(value);
@@ -241,10 +251,18 @@ export default function VisualSearchBar({
   )
 }
 
-function getScreenReaderText(options: AutocompleteResult[]) {
-  return processTranslation({
-    phrase: `${options.length} autocomplete option found.`,
-    pluralForm: `${options.length} autocomplete options found.`,
-    count: options.length
+function getScreenReaderText(autocompleteOptions: number, recentSearchesOptions: number) {
+  const recentSearchesText = recentSearchesOptions > 0 
+    ? processTranslation({
+      phrase: `${recentSearchesOptions} recent search option found.`,
+      pluralForm: `${recentSearchesOptions} recent search options found.`,
+      count: recentSearchesOptions
+    })
+    : '';
+  const autocompleteText = processTranslation({
+    phrase: `${autocompleteOptions} autocomplete option found.`,
+    pluralForm: `${autocompleteOptions} autocomplete options found.`,
+    count: autocompleteOptions
   });
+  return recentSearchesText + ' ' + autocompleteText;
 }

--- a/src/components/VisualAutocomplete/VisualSearchBar.tsx
+++ b/src/components/VisualAutocomplete/VisualSearchBar.tsx
@@ -133,7 +133,7 @@ export default function VisualSearchBar({
           result,
           cssClasses,
           MagnifyingGlassIcon,
-          `autocomplete option: ${result.value}`
+          `autocomplete suggestion: ${result.value}`
         )
       });
 
@@ -192,7 +192,7 @@ export default function VisualSearchBar({
           { value: result.query },
           recentSearchesCssClasses,
           RecentSearchIcon,
-          `recent search option: ${result.query}`
+          `recent search: ${result.query}`
         )
       }
     }) ?? [];
@@ -260,8 +260,8 @@ function getScreenReaderText(autocompleteOptions: number, recentSearchesOptions:
     })
     : '';
   const autocompleteText = processTranslation({
-    phrase: `${autocompleteOptions} autocomplete option found.`,
-    pluralForm: `${autocompleteOptions} autocomplete options found.`,
+    phrase: `${autocompleteOptions} autocomplete suggestion found.`,
+    pluralForm: `${autocompleteOptions} autocomplete suggestions found.`,
     count: autocompleteOptions
   });
   return (recentSearchesText + ' ' + autocompleteText).trim();

--- a/src/components/VisualAutocomplete/VisualSearchBar.tsx
+++ b/src/components/VisualAutocomplete/VisualSearchBar.tsx
@@ -254,8 +254,8 @@ export default function VisualSearchBar({
 function getScreenReaderText(autocompleteOptions: number, recentSearchesOptions: number) {
   const recentSearchesText = recentSearchesOptions > 0 
     ? processTranslation({
-      phrase: `${recentSearchesOptions} recent search option found.`,
-      pluralForm: `${recentSearchesOptions} recent search options found.`,
+      phrase: `${recentSearchesOptions} recent search found.`,
+      pluralForm: `${recentSearchesOptions} recent searches found.`,
       count: recentSearchesOptions
     })
     : '';
@@ -264,5 +264,5 @@ function getScreenReaderText(autocompleteOptions: number, recentSearchesOptions:
     pluralForm: `${autocompleteOptions} autocomplete options found.`,
     count: autocompleteOptions
   });
-  return recentSearchesText + ' ' + autocompleteText;
+  return (recentSearchesText + ' ' + autocompleteText).trim();
 }

--- a/src/components/utils/renderAutocompleteResult.tsx
+++ b/src/components/utils/renderAutocompleteResult.tsx
@@ -19,14 +19,15 @@ export const builtInCssClasses = {
 export default function renderAutocompleteResult(
   result: AutocompleteResult,
   cssClasses?: AutocompleteResultCssClasses,
-  Icon?: React.FunctionComponent<React.SVGProps<SVGSVGElement>>
+  Icon?: React.FunctionComponent<React.SVGProps<SVGSVGElement>>,
+  ariaLabel?: string
 ) {
   cssClasses = cssClasses ?? {};
   return <>
     {Icon && <div className={cssClasses.icon}>
       <Icon />
     </div>}
-    <div className={cssClasses.option}>
+    <div aria-label={ariaLabel || ''} className={cssClasses.option}>
       {renderHighlightedValue(result)}
     </div>
   </>


### PR DESCRIPTION
Update screen reader text in search bar to include number of recent search options, and announce the option type when navigating through the option (e.g. a recent search or an autocomplete option)

J=SLAP-1792
TEST=manual

turn on screen reader on Mac, see that the screen reader announced the right number and type of option for recent searches and autocomplete option.