### PR TITLE
Update query source

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -2100,7 +2100,7 @@ Apache License
 
 The following NPM package may be included in this product:
 
- - @yext/answers-core@1.5.0
+ - @yext/answers-core@1.6.0-beta.0
 
 This package contains the following license and notice below:
 
@@ -2138,7 +2138,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/answers-headless-react@1.1.0-beta.0
+ - @yext/answers-headless-react@1.1.0-beta.1
 
 This package contains the following license and notice below:
 
@@ -2179,7 +2179,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following NPM package may be included in this product:
 
- - @yext/answers-headless@1.1.0-beta.0
+ - @yext/answers-headless@1.1.0-beta.1
 
 This package contains the following license and notice below:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/react-router-dom": "^5.3.0",
         "@typescript-eslint/eslint-plugin": "^4.5.0",
         "@typescript-eslint/parser": "^4.5.0",
-        "@yext/answers-headless-react": "^1.1.0-beta.0",
+        "@yext/answers-headless-react": "^1.1.0-beta.1",
         "autoprefixer": "^9.8.8",
         "babel-eslint": "^10.1.0",
         "babel-loader": "8.1.0",
@@ -4181,9 +4181,9 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
     "node_modules/@yext/answers-core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.5.0.tgz",
-      "integrity": "sha512-Z5xj7dwE6U0ItUV859va5x3FQ9p3tdLIyt2QfkYnFIAhsrTn9zCo95wUWBypO8ERpOW7buNTlavVZovW1pmqJQ==",
+      "version": "1.6.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.6.0-beta.0.tgz",
+      "integrity": "sha512-nT3pkdFRfTlxQwke1X/XZxF4RqRKG2Mb1Pc3abZ3W9wrCtNw1qYXs0TYOA0zki1EiEaX94GzUiFI00gcxgxWNQ==",
       "dependencies": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.1.4"
@@ -4193,22 +4193,22 @@
       }
     },
     "node_modules/@yext/answers-headless": {
-      "version": "1.1.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@yext/answers-headless/-/answers-headless-1.1.0-beta.0.tgz",
-      "integrity": "sha512-SoT6iUZPaGFimGORuzirwpOXX/ItJhTUpD7kfX80P2j3KfCyKFOvC/HCZ+ZKPsutExADHj25V3iyoVd/OcuF6A==",
+      "version": "1.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@yext/answers-headless/-/answers-headless-1.1.0-beta.1.tgz",
+      "integrity": "sha512-y7UZi/wKQ9ymQNDAyFGKhmfJJsAkZQx6owleCsqBt/KnNnbvzTFsa/aPQuLJUzmThFwmvQxQEesDqMKU1Hdc6Q==",
       "dependencies": {
         "@reduxjs/toolkit": "^1.7.0",
-        "@yext/answers-core": "^1.5.0",
+        "@yext/answers-core": "^1.6.0-beta.0",
         "js-levenshtein": "^1.1.6",
         "redux-thunk": "^2.4.1"
       }
     },
     "node_modules/@yext/answers-headless-react": {
-      "version": "1.1.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@yext/answers-headless-react/-/answers-headless-react-1.1.0-beta.0.tgz",
-      "integrity": "sha512-iG0EvuECotouLS33C+5B+Mv37LR1TqMOh8s8a6zEijca3qw+10L/qkrlDlxdTQYws2iQ7pYIiqV0GBEAlnhZtg==",
+      "version": "1.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@yext/answers-headless-react/-/answers-headless-react-1.1.0-beta.1.tgz",
+      "integrity": "sha512-Dib6xiBJf7dDkpw1LwCA8EIYWqYDWJsSzJrCHPeqkuDPeEb9+kYNZK+Wy1dDYA6ZEu/FiEjmx6/kuNdq77VkOA==",
       "dependencies": {
-        "@yext/answers-headless": "^1.1.0-beta.0"
+        "@yext/answers-headless": "^1.1.0-beta.1"
       },
       "peerDependencies": {
         "react": "^17.0.2"
@@ -26353,31 +26353,31 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
     },
     "@yext/answers-core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.5.0.tgz",
-      "integrity": "sha512-Z5xj7dwE6U0ItUV859va5x3FQ9p3tdLIyt2QfkYnFIAhsrTn9zCo95wUWBypO8ERpOW7buNTlavVZovW1pmqJQ==",
+      "version": "1.6.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@yext/answers-core/-/answers-core-1.6.0-beta.0.tgz",
+      "integrity": "sha512-nT3pkdFRfTlxQwke1X/XZxF4RqRKG2Mb1Pc3abZ3W9wrCtNw1qYXs0TYOA0zki1EiEaX94GzUiFI00gcxgxWNQ==",
       "requires": {
         "@babel/runtime-corejs3": "^7.12.5",
         "cross-fetch": "^3.1.4"
       }
     },
     "@yext/answers-headless": {
-      "version": "1.1.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@yext/answers-headless/-/answers-headless-1.1.0-beta.0.tgz",
-      "integrity": "sha512-SoT6iUZPaGFimGORuzirwpOXX/ItJhTUpD7kfX80P2j3KfCyKFOvC/HCZ+ZKPsutExADHj25V3iyoVd/OcuF6A==",
+      "version": "1.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@yext/answers-headless/-/answers-headless-1.1.0-beta.1.tgz",
+      "integrity": "sha512-y7UZi/wKQ9ymQNDAyFGKhmfJJsAkZQx6owleCsqBt/KnNnbvzTFsa/aPQuLJUzmThFwmvQxQEesDqMKU1Hdc6Q==",
       "requires": {
         "@reduxjs/toolkit": "^1.7.0",
-        "@yext/answers-core": "^1.5.0",
+        "@yext/answers-core": "^1.6.0-beta.0",
         "js-levenshtein": "^1.1.6",
         "redux-thunk": "^2.4.1"
       }
     },
     "@yext/answers-headless-react": {
-      "version": "1.1.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@yext/answers-headless-react/-/answers-headless-react-1.1.0-beta.0.tgz",
-      "integrity": "sha512-iG0EvuECotouLS33C+5B+Mv37LR1TqMOh8s8a6zEijca3qw+10L/qkrlDlxdTQYws2iQ7pYIiqV0GBEAlnhZtg==",
+      "version": "1.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@yext/answers-headless-react/-/answers-headless-react-1.1.0-beta.1.tgz",
+      "integrity": "sha512-Dib6xiBJf7dDkpw1LwCA8EIYWqYDWJsSzJrCHPeqkuDPeEb9+kYNZK+Wy1dDYA6ZEu/FiEjmx6/kuNdq77VkOA==",
       "requires": {
-        "@yext/answers-headless": "^1.1.0-beta.0"
+        "@yext/answers-headless": "^1.1.0-beta.1"
       }
     },
     "abab": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@types/react-router-dom": "^5.3.0",
     "@typescript-eslint/eslint-plugin": "^4.5.0",
     "@typescript-eslint/parser": "^4.5.0",
-    "@yext/answers-headless-react": "^1.1.0-beta.0",
+    "@yext/answers-headless-react": "^1.1.0-beta.1",
     "autoprefixer": "^9.8.8",
     "babel-eslint": "^10.1.0",
     "babel-loader": "8.1.0",

--- a/src/PageRouter.tsx
+++ b/src/PageRouter.tsx
@@ -11,7 +11,7 @@ interface RouteData {
 export type LayoutComponent = ComponentType<{ page: JSX.Element }>
 
 export interface BrowserState {
-  originalQuerySource?: QuerySource
+  querySource?: QuerySource
 }
 
 interface PageProps {

--- a/src/PageRouter.tsx
+++ b/src/PageRouter.tsx
@@ -1,3 +1,4 @@
+import { QuerySource } from '@yext/answers-headless-react';
 import { ComponentType } from 'react';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 
@@ -8,6 +9,10 @@ interface RouteData {
 }
 
 export type LayoutComponent = ComponentType<{ page: JSX.Element }>
+
+export interface BrowserState {
+  originalQuerySource?: QuerySource
+}
 
 interface PageProps {
   Layout?: LayoutComponent,

--- a/src/components/AlternativeVerticals.tsx
+++ b/src/components/AlternativeVerticals.tsx
@@ -138,7 +138,7 @@ export default function AlternativeVerticals ({
   function renderSuggestion(suggestion: VerticalSuggestion) {
     return (
       <li key={suggestion.verticalKey} className={cssClasses.suggestion}>
-        <Link className={cssClasses.suggestionButton} to={`/${suggestion.verticalKey}`}>
+        <Link className={cssClasses.suggestionButton} to={`/${suggestion.verticalKey}?query=${query}`}>
           <div className={cssClasses.verticalIcon}><Star/></div>
           <span className={cssClasses.verticalLink}>{suggestion.label}</span>
         </Link>
@@ -150,7 +150,7 @@ export default function AlternativeVerticals ({
     return (
       <div className={cssClasses.categoriesText}>
         <span>View results across </span>
-        <Link className={cssClasses.allCategoriesLink} to='/'>
+        <Link className={cssClasses.allCategoriesLink} to={`/?query=${query}`}>
           all search categories.
         </Link>
       </div>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -53,6 +53,7 @@ interface NavigationProps {
 export default function Navigation({ links, customCssClasses, cssCompositionMethod }: NavigationProps) {
   const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses, cssCompositionMethod);
   const currentVertical = useAnswersState(state => state.vertical.verticalKey);
+  const query = useAnswersState(state => state.query.input) ?? '';
 
   // Close the menu when clicking the document
   const [menuOpen, setMenuOpen] = useState<boolean>(false);
@@ -107,7 +108,7 @@ export default function Navigation({ links, customCssClasses, cssCompositionMeth
 
   return (
     <nav className={cssClasses.nav} ref={navigationRef}>
-      {visibleLinks.map((l, index) => renderLink(l, index === activeVisibleLinkIndex, cssClasses))}
+      {visibleLinks.map((l, index) => renderLink(l, query, index === activeVisibleLinkIndex, cssClasses))}
       {numOverflowLinks > 0 &&
         <div className={cssClasses.menuButtonContainer}>
           <button
@@ -119,7 +120,7 @@ export default function Navigation({ links, customCssClasses, cssCompositionMeth
           </button>
           {menuOpen && 
             <div className={cssClasses.menuContainer}>
-              {menuOpen && overflowLinks.map((l, index) => renderLink(l, index === activeMenuLinkIndex, {
+              {menuOpen && overflowLinks.map((l, index) => renderLink(l, query, index === activeMenuLinkIndex, {
                 navLink: cssClasses.menuNavLink,
                 navLinkContainer: cssClasses.menuNavLinkContainer,
                 navLinkContainer___active: cssClasses.menuNavLinkContainer___active
@@ -134,6 +135,7 @@ export default function Navigation({ links, customCssClasses, cssCompositionMeth
 
 function renderLink(
   linkData: LinkData,
+  query: string,
   isActiveLink: boolean,
   cssClasses: { navLinkContainer?: string, navLinkContainer___active?: string, navLink?: string }) 
 {
@@ -145,7 +147,7 @@ function renderLink(
     <div className={navLinkContainerClasses} key={to}>
       <NavLink
         className={cssClasses.navLink}
-        to={`${to}`}
+        to={`${to}?query=${query}`}
         exact={true}
       >
         {label}

--- a/src/components/SpellCheck.tsx
+++ b/src/components/SpellCheck.tsx
@@ -1,5 +1,6 @@
-import { useAnswersState, useAnswersActions, SearchTypeEnum } from '@yext/answers-headless-react'
+import { useAnswersState, useAnswersActions } from '@yext/answers-headless-react'
 import classNames from 'classnames';
+import { useHistory } from 'react-router-dom';
 import { CompositionMethod, useComposedCssClasses } from '../hooks/useComposedCssClasses';
 
 interface SpellCheckCssClasses {
@@ -22,7 +23,7 @@ interface Props {
 }
 
 export default function SpellCheck ({ customCssClasses, cssCompositionMethod }: Props): JSX.Element | null {
-  const isVertical = useAnswersState(s => s.meta.searchType) === SearchTypeEnum.Vertical;
+  const verticalKey = useAnswersState(state => state.vertical.verticalKey) ?? '';
   const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses, cssCompositionMethod);
   const correctedQuery = useAnswersState(state => state.spellCheck.correctedQuery);
   const isLoading = useAnswersState(state => state.searchStatus.isLoading);
@@ -30,6 +31,7 @@ export default function SpellCheck ({ customCssClasses, cssCompositionMethod }: 
     ? classNames(cssClasses.container, { [cssClasses.spellCheck___loading]: isLoading })
     : cssClasses.container;
   const answersActions = useAnswersActions();
+  const browserHistory = useHistory();
   if (!correctedQuery) {
     return null;
   }
@@ -38,9 +40,7 @@ export default function SpellCheck ({ customCssClasses, cssCompositionMethod }: 
       <span className={cssClasses.helpText}>Did you mean </span>
       <button className={cssClasses.link} onClick={() => {
         answersActions.setQuery(correctedQuery);
-        isVertical
-          ? answersActions.executeVerticalQuery()
-          : answersActions.executeUniversalQuery();
+        browserHistory.push(`/${verticalKey}?query=${correctedQuery}`);
       }}>{correctedQuery}</button>
     </div>
   );

--- a/src/components/VisualAutocomplete/VisualSearchBar.tsx
+++ b/src/components/VisualAutocomplete/VisualSearchBar.tsx
@@ -81,7 +81,6 @@ export default function VisualSearchBar({
   const answersActions = useAnswersActions();
   const answersUtilities = useAnswersUtilities();
   const query = useAnswersState(state => state.query.input) ?? '';
-  const querySource = useAnswersState(state => state.query.querySource);
   const isLoading = useAnswersState(state => state.searchStatus.isLoading) ?? false;
   const [executeQueryWithNearMeHandling, autocompletePromiseRef] = useSearchWithNearMeHandling(answersActions);
   const [autocompleteResponse, executeAutocomplete] = useSynchronizedRequest(async () => {
@@ -156,9 +155,8 @@ export default function VisualSearchBar({
           onSelect: () => {
             autocompletePromiseRef.current = undefined;
             answersActions.setQuery(result.value);
-            answersActions.setQuerySource(QuerySource.Autocomplete);
             browserHistory.push(`/${link.verticalKey}`, {
-              originalQuerySource: querySource
+              querySource: QuerySource.Autocomplete
             });
           },
           display: renderAutocompleteResult({ value: `in ${link.label}` }, { ...cssClasses, option: cssClasses.verticalLink })

--- a/src/components/VisualAutocomplete/VisualSearchBar.tsx
+++ b/src/components/VisualAutocomplete/VisualSearchBar.tsx
@@ -1,4 +1,4 @@
-import { useAnswersActions, useAnswersState, useAnswersUtilities, VerticalResults } from '@yext/answers-headless-react';
+import { useAnswersActions, useAnswersState, useAnswersUtilities, QuerySource, VerticalResults } from '@yext/answers-headless-react';
 import { PropsWithChildren, useEffect, useState } from 'react';
 import InputDropdown from '../InputDropdown';
 import '../../sass/Autocomplete.scss';
@@ -17,6 +17,7 @@ import { ReactComponent as RecentSearchIcon } from '../../icons/history.svg';
 import useRecentSearches from '../../hooks/useRecentSearches';
 import { useHistory } from 'react-router';
 import { ReactComponent as MagnifyingGlassIcon } from '../../icons/magnifying_glass.svg';
+import { BrowserState } from '../../PageRouter';
 
 const SCREENREADER_INSTRUCTIONS = 'When autocomplete results are available, use up and down arrows to review and enter to select.'
 const builtInCssClasses: VisualSearchBarCssClasses = { 
@@ -76,10 +77,11 @@ export default function VisualSearchBar({
 }: PropsWithChildren<Props>) {
   const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses, cssCompositionMethod);
 
-  const browserHistory = useHistory();
+  const browserHistory = useHistory<BrowserState>();
   const answersActions = useAnswersActions();
   const answersUtilities = useAnswersUtilities();
   const query = useAnswersState(state => state.query.input) ?? '';
+  const querySource = useAnswersState(state => state.query.querySource);
   const isLoading = useAnswersState(state => state.searchStatus.isLoading) ?? false;
   const [executeQueryWithNearMeHandling, autocompletePromiseRef] = useSearchWithNearMeHandling(answersActions);
   const [autocompleteResponse, executeAutocomplete] = useSynchronizedRequest(async () => {
@@ -154,8 +156,10 @@ export default function VisualSearchBar({
           onSelect: () => {
             autocompletePromiseRef.current = undefined;
             answersActions.setQuery(result.value);
-            executeQuery();
-            browserHistory.push(`/${link.verticalKey}`);
+            answersActions.setQuerySource(QuerySource.Autocomplete);
+            browserHistory.push(`/${link.verticalKey}`, {
+              originalQuerySource: querySource
+            });
           },
           display: renderAutocompleteResult({ value: `in ${link.label}` }, { ...cssClasses, option: cssClasses.verticalLink })
         })

--- a/src/components/VisualAutocomplete/VisualSearchBar.tsx
+++ b/src/components/VisualAutocomplete/VisualSearchBar.tsx
@@ -155,7 +155,7 @@ export default function VisualSearchBar({
           onSelect: () => {
             autocompletePromiseRef.current = undefined;
             answersActions.setQuery(result.value);
-            browserHistory.push(`/${link.verticalKey}`, {
+            browserHistory.push(`/${link.verticalKey}?query=${result.value}`, {
               querySource: QuerySource.Autocomplete
             });
           },

--- a/src/hooks/useEntityPreviews.tsx
+++ b/src/hooks/useEntityPreviews.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from "react";
-import { provideAnswersHeadless, useAnswersState, VerticalResults, AnswersHeadless, UniversalLimit, QuerySource } from '@yext/answers-headless-react';
+import { provideAnswersHeadless, VerticalResults, AnswersHeadless, UniversalLimit, QuerySource } from '@yext/answers-headless-react';
 import { answersHeadlessConfig } from '../config/answersHeadlessConfig';
 import useDebouncedFunction from './useDebouncedFunction';
 import useComponentMountStatus from "./useComponentMountStatus";

--- a/src/hooks/useEntityPreviews.tsx
+++ b/src/hooks/useEntityPreviews.tsx
@@ -25,15 +25,14 @@ export function useEntityPreviews(headlessId: string, debounceTime: number):[ En
       ...answersHeadlessConfig,
       headlessId
     });
+    headlessRef.current.setQuerySource(QuerySource.Autocomplete);
   }
   const isMountedRef = useComponentMountStatus();
   const [verticalResultsArray, setVerticalResultsArray] = useState<VerticalResults[]>([]);
-  const querySource = useAnswersState(state => state.query.querySource);
   const debouncedUniversalSearch = useDebouncedFunction(async () => {
     if (!headlessRef.current) {
       return;
     }
-    headlessRef.current.setQuerySource(QuerySource.Autocomplete);
     await headlessRef.current.executeUniversalQuery();
     /**
      * Avoid performing a React state update on an unmounted component
@@ -45,7 +44,6 @@ export function useEntityPreviews(headlessId: string, debounceTime: number):[ En
     const results = headlessRef.current.state.universal.verticals || [];
     setVerticalResultsArray(results);
     setLoadingState(false);
-    headlessRef.current.setQuerySource(querySource ?? QuerySource.Standard);
   }, debounceTime);
   const [isLoading, setLoadingState] = useState<boolean>(false);
 

--- a/src/hooks/useEntityPreviews.tsx
+++ b/src/hooks/useEntityPreviews.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from "react";
-import { provideAnswersHeadless, VerticalResults, AnswersHeadless, UniversalLimit } from '@yext/answers-headless-react';
+import { provideAnswersHeadless, useAnswersState, VerticalResults, AnswersHeadless, UniversalLimit, QuerySource } from '@yext/answers-headless-react';
 import { answersHeadlessConfig } from '../config/answersHeadlessConfig';
 import useDebouncedFunction from './useDebouncedFunction';
 import useComponentMountStatus from "./useComponentMountStatus";
@@ -28,10 +28,12 @@ export function useEntityPreviews(headlessId: string, debounceTime: number):[ En
   }
   const isMountedRef = useComponentMountStatus();
   const [verticalResultsArray, setVerticalResultsArray] = useState<VerticalResults[]>([]);
+  const querySource = useAnswersState(state => state.query.querySource);
   const debouncedUniversalSearch = useDebouncedFunction(async () => {
     if (!headlessRef.current) {
       return;
     }
+    headlessRef.current.setQuerySource(QuerySource.Autocomplete);
     await headlessRef.current.executeUniversalQuery();
     /**
      * Avoid performing a React state update on an unmounted component
@@ -43,7 +45,8 @@ export function useEntityPreviews(headlessId: string, debounceTime: number):[ En
     const results = headlessRef.current.state.universal.verticals || [];
     setVerticalResultsArray(results);
     setLoadingState(false);
-  }, debounceTime)
+    headlessRef.current.setQuerySource(querySource ?? QuerySource.Standard);
+  }, debounceTime);
   const [isLoading, setLoadingState] = useState<boolean>(false);
 
   function executeEntityPreviewsQuery(query: string, universalLimit: UniversalLimit, restrictVerticals: string[]) {

--- a/src/hooks/usePageSetupEffect.tsx
+++ b/src/hooks/usePageSetupEffect.tsx
@@ -24,12 +24,23 @@ export default function usePageSetupEffect(verticalKey?: string) {
     verticalKey
       ? answersActions.setVertical(verticalKey)
       : answersActions.setUniversal();
+
     const executeQuery = async () => {
       let searchIntents: SearchIntent[] = [];
       if (!answersActions.state.location.userLocation) {
         searchIntents = await getSearchIntents(answersActions, !!verticalKey) || [];
         await updateLocationIfNeeded(answersActions, searchIntents);
       }
+
+      if (browserLocation.search) {
+        const queryParamTerm = 'query='
+        const queryIndex = browserLocation.search.indexOf(queryParamTerm);
+        if (queryIndex >= 0) {
+          const encodedQuery = browserLocation.search.slice(queryIndex + queryParamTerm.length);
+          answersActions.setQuery(decodeURI(encodedQuery));
+        }
+      }
+
       if (browserLocation.state?.querySource) {
         const querySource = answersActions.state.query.querySource;
         answersActions.setQuerySource(browserLocation.state.querySource);
@@ -39,6 +50,7 @@ export default function usePageSetupEffect(verticalKey?: string) {
         executeSearch(answersActions, !!verticalKey);
       }
     };
+
     executeQuery();
-  }, [answersActions, verticalKey, browserLocation.state]);
+  }, [answersActions, verticalKey, browserLocation]);
 }

--- a/src/hooks/usePageSetupEffect.tsx
+++ b/src/hooks/usePageSetupEffect.tsx
@@ -1,6 +1,8 @@
 import { useLayoutEffect } from "react";
-import { useAnswersActions, SearchIntent } from "@yext/answers-headless-react";
+import { useAnswersActions, SearchIntent, QuerySource } from "@yext/answers-headless-react";
 import { executeSearch, getSearchIntents, updateLocationIfNeeded } from "../utils/search-operations";
+import { useLocation } from "react-router";
+import { BrowserState } from "../PageRouter";
 
 /**
  * Sets up the state for a page
@@ -8,6 +10,7 @@ import { executeSearch, getSearchIntents, updateLocationIfNeeded } from "../util
  */
 export default function usePageSetupEffect(verticalKey?: string) {
   const answersActions = useAnswersActions();
+  const browserLocation = useLocation<BrowserState>();
   useLayoutEffect(() => {
     const stateToClear = {
       filters: {},
@@ -28,7 +31,10 @@ export default function usePageSetupEffect(verticalKey?: string) {
         await updateLocationIfNeeded(answersActions, searchIntents);
       }
       executeSearch(answersActions, !!verticalKey);
+      if (browserLocation.state) {
+        answersActions.setQuerySource(browserLocation.state.originalQuerySource ?? QuerySource.Standard);
+      }
     };
     executeQuery();
-  }, [answersActions, verticalKey]);
+  }, [answersActions, verticalKey, browserLocation.state]);
 }

--- a/src/hooks/usePageSetupEffect.tsx
+++ b/src/hooks/usePageSetupEffect.tsx
@@ -30,9 +30,13 @@ export default function usePageSetupEffect(verticalKey?: string) {
         searchIntents = await getSearchIntents(answersActions, !!verticalKey) || [];
         await updateLocationIfNeeded(answersActions, searchIntents);
       }
-      executeSearch(answersActions, !!verticalKey);
-      if (browserLocation.state) {
-        answersActions.setQuerySource(browserLocation.state.originalQuerySource ?? QuerySource.Standard);
+      if (browserLocation.state?.querySource) {
+        const querySource = answersActions.state.query.querySource;
+        answersActions.setQuerySource(browserLocation.state.querySource);
+        executeSearch(answersActions, !!verticalKey);
+        answersActions.setQuerySource(querySource ?? QuerySource.Standard);
+      } else {
+        executeSearch(answersActions, !!verticalKey);
       }
     };
     executeQuery();

--- a/src/hooks/usePageSetupEffect.tsx
+++ b/src/hooks/usePageSetupEffect.tsx
@@ -35,7 +35,7 @@ export default function usePageSetupEffect(verticalKey?: string) {
       if (browserLocation.search) {
         const params = new URLSearchParams(browserLocation.search);
         const queryParam = params.get('query');
-        queryParam && answersActions.setQuery(queryParam);
+        queryParam !== null && answersActions.setQuery(queryParam);
       }
 
       if (browserLocation.state?.querySource) {

--- a/src/hooks/usePageSetupEffect.tsx
+++ b/src/hooks/usePageSetupEffect.tsx
@@ -33,12 +33,9 @@ export default function usePageSetupEffect(verticalKey?: string) {
       }
 
       if (browserLocation.search) {
-        const queryParamTerm = 'query='
-        const queryIndex = browserLocation.search.indexOf(queryParamTerm);
-        if (queryIndex >= 0) {
-          const encodedQuery = browserLocation.search.slice(queryIndex + queryParamTerm.length);
-          answersActions.setQuery(decodeURI(encodedQuery));
-        }
+        const params = new URLSearchParams(browserLocation.search);
+        const queryParam = params.get('query');
+        queryParam && answersActions.setQuery(queryParam);
       }
 
       if (browserLocation.state?.querySource) {

--- a/src/hooks/useSearchWithNearMeHandling.ts
+++ b/src/hooks/useSearchWithNearMeHandling.ts
@@ -1,7 +1,8 @@
 import { AnswersHeadless, SearchTypeEnum } from '@yext/answers-headless-react';
-import { executeSearch, updateLocationIfNeeded } from '../utils/search-operations';
+import { updateLocationIfNeeded } from '../utils/search-operations';
 import { MutableRefObject, useRef } from 'react';
 import { AutocompleteResponse, SearchIntent } from '@yext/answers-headless-react';
+import { useHistory } from 'react-router-dom';
 
 type QueryFunc = () => Promise<void>
 type AutocompleteRef = MutableRefObject<Promise<AutocompleteResponse | undefined> | undefined>
@@ -22,6 +23,8 @@ export default function useSearchWithNearMeHandling(
    */
   const autocompletePromiseRef = useRef<Promise<AutocompleteResponse | undefined>>();
   const isVertical = answersActions.state.meta.searchType === SearchTypeEnum.Vertical;
+  const verticalKey = answersActions.state.vertical.verticalKey ?? '';
+  const browserHistory = useHistory();
 
   async function executeQuery() {
     let intents: SearchIntent[] = [];
@@ -35,7 +38,8 @@ export default function useSearchWithNearMeHandling(
       intents = autocompleteResponseBeforeSearch?.inputIntents || [];
       await updateLocationIfNeeded(answersActions, intents, geolocationOptions);
     }
-    executeSearch(answersActions, isVertical);
+    const query = answersActions.state.query.input ?? '';
+    browserHistory.push(`/${verticalKey}?query=${query}`);
   }
   return [executeQuery, autocompletePromiseRef];
 }

--- a/tests/wcag/tests.js
+++ b/tests/wcag/tests.js
@@ -11,23 +11,23 @@ const universalSearchTests = [
 const verticalSearchTests = [
   {
     name: 'vertical-search',
-    commands: [{ type: 'click', params: ['a[href="/events"]'] }]
+    commands: [{ type: 'click', params: ['a[href="/events?query="]'] }]
   },
   {
     name: 'vertical-search--no-results',
     commands: [
-      { type: 'click', params: ['a[href="/jobs"]'] },
+      { type: 'click', params: ['a[href="/jobs?query="]'] },
       { type: 'search', params: ['zelle', 'input'] }
     ]
   },
   {
     name: 'vertical-search--locations',
-    commands: [{ type: 'click', params: ['a[href="/locations"]'] }]
+    commands: [{ type: 'click', params: ['a[href="/locations?query="]'] }]
   },
   {
     name: 'vertical-search--faqs',
     commands: [
-      { type: 'click', params: ['a[href="/faqs"]'] }]
+      { type: 'click', params: ['a[href="/faqs?query="]'] }]
   }
 ];
 


### PR DESCRIPTION
Use the "AUTOCOMPLETE" query source when hitting the universal endpoint from visual autocomplete to get entity previews and when hitting the vertical endpoint from clicking on a vertical link. Also add the query param to the URL so refreshing and browser history is accurate.

J=SLAP-1801
TEST=manual

Check that requests from VA entity previews and from clicking vertical links have `source=AUTOCOMPLETE` but other searches from VA or the regular search bar have the original source. Also check that the URL query param works as expected.