### PR TITLE
fix renderHighlighedValue styling

### DIFF
--- a/src/components/utils/renderHighlightedValue.tsx
+++ b/src/components/utils/renderHighlightedValue.tsx
@@ -1,8 +1,8 @@
 import { HighlightedValue } from "@yext/answers-headless-react";
 
 const defaultCssClasses: HighlightedValueCssClasses = {
-  highlighted: 'font-normal',
-  nonHighlighted: 'font-semibold'
+  highlighted: 'font-semibold',
+  nonHighlighted: 'font-normal'
 }
 
 interface HighlightedValueCssClasses {


### PR DESCRIPTION
It appears that the default css classes are flipped.

TEST=manual

see that highlighted values dont have flipped styling