### PR TITLE
Support custom card component

### DIFF
--- a/src/components/VerticalResults.tsx
+++ b/src/components/VerticalResults.tsx
@@ -1,4 +1,4 @@
-import { CardComponent, CardConfigTypes } from '../models/cardComponent';
+import { CardComponent } from '../models/cardComponent';
 import { useAnswersState, Result, useAnswersActions } from '@yext/answers-headless-react';
 import classNames from 'classnames';
 import { CompositionMethod, useComposedCssClasses } from '../hooks/useComposedCssClasses';
@@ -14,7 +14,7 @@ const builtInCssClasses: VerticalResultsCssClasses = {
 
 interface VerticalResultsDisplayProps {
   CardComponent: CardComponent,
-  cardConfig?: CardConfigTypes,
+  cardConfig?: Record<string, unknown>,
   isLoading?: boolean,
   results: Result[],
   customCssClasses?: VerticalResultsCssClasses,
@@ -53,13 +53,13 @@ export function VerticalResultsDisplay(props: VerticalResultsDisplayProps): JSX.
  * @param cardConfig - Any card-specific configuration.
  * @param result - The result to render.
  */
-function renderResult(CardComponent: CardComponent, cardConfig: CardConfigTypes, result: Result): JSX.Element {
-  return <CardComponent result={result} configuration={cardConfig} key={result.id || result.index}/>;
+function renderResult(CardComponent: CardComponent, cardConfig: Record<string, unknown>, result: Result): JSX.Element {
+  return <CardComponent result={result} {...cardConfig} key={result.id || result.index}/>;
 }
 
 interface VerticalResultsProps {
   CardComponent: CardComponent,
-  cardConfig?: CardConfigTypes,
+  cardConfig?: Record<string, unknown>,
   displayAllOnNoResults?: boolean,
   customCssClasses?: VerticalResultsCssClasses,
   cssCompositionMethod?: CompositionMethod,

--- a/src/components/cards/StandardCard.tsx
+++ b/src/components/cards/StandardCard.tsx
@@ -1,12 +1,9 @@
 import { CompositionMethod, useComposedCssClasses } from '../../hooks/useComposedCssClasses';
 import { CardProps } from '../../models/cardComponent';
 
-export interface StandardCardConfig {
-  showOrdinal?: boolean
-}
 
 export interface StandardCardProps extends CardProps {
-  configuration: StandardCardConfig,
+  showOrdinal?: boolean,
   customCssClasses?: StandardCardCssClasses,
   cssCompositionMethod?: CompositionMethod
 }
@@ -57,7 +54,7 @@ function isCtaData(data: unknown): data is CtaData {
  * @param props - An object containing the result itself.
  */
 export function StandardCard(props: StandardCardProps): JSX.Element {
-  const { configuration, result, customCssClasses, cssCompositionMethod } = props;
+  const { showOrdinal, result, customCssClasses, cssCompositionMethod } = props;
   const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses, cssCompositionMethod);
 
   const cta1 = isCtaData(result.rawData.c_primaryCTA) ? result.rawData.c_primaryCTA : undefined;
@@ -90,7 +87,7 @@ export function StandardCard(props: StandardCardProps): JSX.Element {
   return (
     <div className={cssClasses.container}>
       <div className={cssClasses.header}>
-        {configuration.showOrdinal && result.index && renderOrdinal(result.index)}
+        {showOrdinal && result.index && renderOrdinal(result.index)}
         {result.name && renderTitle(result.name)}
       </div>
       {(result.description ?? cta1 ?? cta2) &&

--- a/src/components/sections/StandardSection.tsx
+++ b/src/components/sections/StandardSection.tsx
@@ -31,7 +31,7 @@ const StandardSection: SectionComponent = function (props: StandardSectionConfig
       <VerticalResultsDisplay
         results={results}
         CardComponent={cardComponent}
-        {...(cardConfig && { cardConfig })}
+        {...cardConfig}
       />
     </section>
   );

--- a/src/models/cardComponent.ts
+++ b/src/models/cardComponent.ts
@@ -1,16 +1,11 @@
 import { Result } from '@yext/answers-headless-react';
-import { StandardCardConfig } from '../components/cards/StandardCard';
-
-/**
- * The config types for each supported card.
- */
-export type CardConfigTypes = StandardCardConfig;
 
 /**
  * CardComponent and the corresponding config options
  */
-export interface CardConfig extends CardConfigTypes {
-  CardComponent: CardComponent
+export interface CardConfig {
+  CardComponent: CardComponent,
+  [otherProps: string]: unknown
 }
 
 /**
@@ -18,7 +13,7 @@ export interface CardConfig extends CardConfigTypes {
  */
 export interface CardProps {
   result: Result,
-  configuration: CardConfigTypes
+  [otherProps: string]: unknown
 }
 
 /**

--- a/src/pagebuilder/PageBuilderApp.tsx
+++ b/src/pagebuilder/PageBuilderApp.tsx
@@ -6,7 +6,7 @@ import VerticalStandardPage from './templates/VerticalStandardPage';
 import { AnswersAppContextProvider } from './AnswersAppContext';
 import { UniversalResultsConfig } from '../components/UniversalResults';
 import UniversalStandardPage from './templates/UniversalStandardPage';
-import { CardNameToComponentMap } from './templates/componentMapping';
+import { CardRegistry } from './templates/componentRegistry';
 import { LinkData } from '../components/Navigation';
 import { UniversalPageConfig } from './models/UniversalPageConfig';
 import { VerticalPageConfigs } from './models/VerticalPageConfig';
@@ -52,7 +52,7 @@ function constructPageRoutes(universal: UniversalPageConfig, verticals: Vertical
   const universalResultsConfig : UniversalResultsConfig = {};
   const navLinks = constructNavigationLinks(universal, verticals);
   Object.entries(verticals).forEach(([key, config]) => {
-    const CardComponent = CardNameToComponentMap[config.cardConfig?.cardName || 'STANDARD'];
+    const CardComponent = CardRegistry[config.cardConfig?.cardName || 'Standard'];
     universalResultsConfig[key] = { 
       label: config.label || key,
       cardConfig: { CardComponent }

--- a/src/pagebuilder/commands/cardcreator.js
+++ b/src/pagebuilder/commands/cardcreator.js
@@ -1,0 +1,128 @@
+const fs = require('fs-extra');
+const path = require('path');
+const UserError = require('./helpers/errors/usererror');
+const { ArgumentMetadata, ArgumentType } = require('./helpers/utils/argumentmetadata');
+
+/**
+ * CardCreator represents the `card` custom jambo command.
+ * The command creates a new, custom card in the top-level 'cards' directory
+ * of a jambo repo.
+ */
+class CardCreator {
+  constructor(jamboConfig) {
+    this.config = jamboConfig;
+    this._customCardsDir = 'cards';
+  }
+
+  /**
+   * @returns {string} the alias for the create card command.
+   */
+  static getAlias() {
+    return 'card';
+  }
+
+  /**
+   * @returns {string} a short description of the create card command.
+   */
+  static getShortDescription() {
+    return 'add a new card for use in the React app';
+  }
+
+  /**
+   * @returns {Object<string, ArgumentMetadata>} description of each argument for 
+   *                                             the create card command, keyed by name
+   */
+  static args() {
+    return {
+      'name': new ArgumentMetadata(ArgumentType.STRING, 'name for the new card', true),
+      'cardTemplateFilePath': new ArgumentMetadata(ArgumentType.STRING, 'file path of card template', true)
+    };
+  }
+
+  /**
+   * @returns {Object} description of the card command
+   */
+  static describe(jamboConfig) {
+    return {
+      displayName: 'Add Card',
+      params: {
+        name: {
+          displayName: 'Card Name',
+          required: true,
+          type: 'string'
+        },
+        cardTemplateFilePath: {
+          displayName: 'Card Template\' File Path',
+          required: true,
+          type: 'string'
+        }
+      }
+    };
+  }
+
+  /**
+   * Executes the create card command with the provided arguments.
+   * 
+   * @param {Object<string, string>} args The arguments, keyed by name 
+   */
+  execute(args) {
+    this._create(args.name, args.cardTemplateFilePath);
+  }
+
+  /**
+   * Creates a new, custom card in the top-level 'Cards' directory. This card
+   * will be based off the card template from the given file path.
+   * 
+   * @param {string} newComponentName The name of the new card. A React component
+   *                                  file with this name will be created.
+   * @param {string} cardTemplateFilePath The file path of the existing card in which
+   *                                      the new one will be based on.
+   */
+  _create(newComponentName, cardTemplateFilePath) {
+    if (!(/^[A-Z][\w_]+$/.test(newComponentName))) {
+      throw new UserError(`${newComponentName} is not a valid React component name.`);
+    }
+    const newCardFilePath = `${this._customCardsDir}/${newComponentName}.tsx`;
+    if (fs.existsSync(newCardFilePath)) {
+      throw new UserError(`A card component file with this name '${newComponentName}'` 
+        + ` already exists in file path: ${newCardFilePath}`);
+    }
+    if (!fs.existsSync(cardTemplateFilePath)) {
+      throw new UserError(`Template for card component does not exist in file path: ${cardTemplateFilePath}`);
+    }
+    this._createNewComponentFile(newComponentName, newCardFilePath, cardTemplateFilePath);
+    this._updateCardRegistry(newComponentName);
+  }
+
+  /**
+   * Creates a new component file in 'cards' directory with modified content from
+   * the specified card template file, in which the original component's name is replaced
+   * with the new component's name.
+   * 
+   * @param {string} newComponentName 
+   * @param {string} newCardFilePath 
+   * @param {string} cardTemplateFilePath 
+   */
+  _createNewComponentFile(newComponentName, newCardFilePath, cardTemplateFilePath) {
+    !fs.existsSync(this._customCardsDir) && fs.mkdirSync(this._customCardsDir);
+    const fileContent = fs.readFileSync(cardTemplateFilePath).toString();
+    const originalComponentName = path.basename(cardTemplateFilePath, '.tsx');
+    const newFileContext = fileContent.replace(new RegExp(originalComponentName, 'g'), newComponentName);
+    fs.writeFileSync(newCardFilePath, newFileContext);
+  }
+
+  /**
+   * Registers new component to the card registry by directly modify content in componentRegistry.ts
+   * 
+   * @param {string} newComponentName 
+   */
+  _updateCardRegistry(newComponentName) {
+    const registryFilePath = './templates/componentRegistry.ts';
+    const registryContent = fs.readFileSync(registryFilePath).toString();
+    const newRegistryContent = `import { ${newComponentName} } from "../cards/${newComponentName}";\n`
+      + registryContent.replace(/(export enum CardTypes {\n)(.*)/gs, `$1\t${newComponentName} = '${newComponentName}',\n$2`)
+      + `\nCardRegistry[CardTypes.${newComponentName}] = ${newComponentName}`;
+    fs.writeFileSync(registryFilePath, newRegistryContent);
+  }
+}
+module.exports = CardCreator;

--- a/src/pagebuilder/commands/helpers/errors/usererror.js
+++ b/src/pagebuilder/commands/helpers/errors/usererror.js
@@ -1,0 +1,20 @@
+/**
+ * Represents errors that we may reasonably expect a user to make
+ */
+class UserError extends Error {  
+  constructor(message, stack) {
+    super(message);
+
+    if (stack) {
+      this.stack = stack;
+      this.message = message;
+    } else {
+      Error.captureStackTrace(this, this.constructor);
+    }
+
+    this.name = 'UserError'
+    this.exitCode = 13;
+  }
+}
+
+module.exports = UserError;

--- a/src/pagebuilder/commands/helpers/utils/argumentmetadata.js
+++ b/src/pagebuilder/commands/helpers/utils/argumentmetadata.js
@@ -1,0 +1,60 @@
+/**
+ * An enum describing the different kinds of argument that are supported.
+ */
+const ArgumentType = {
+  STRING: 'string',
+  NUMBER: 'number',
+  BOOLEAN: 'boolean',
+  ARRAY: 'array'
+}
+Object.freeze(ArgumentType);
+
+/**
+ * A class outlining the metadata for a {@link Command}'s argument. This includes
+ * the type of the argument's values, if it is required, and an optional default.
+ */
+class ArgumentMetadata {
+  constructor(type, description, isRequired, defaultValue, itemType) {
+    this._type = type;
+    this._description = description;
+    this._isRequired = isRequired;
+    this._defaultValue = defaultValue;
+    this._itemType = itemType;
+  }
+
+  /**
+   * @returns {ArgumentType} The type of the argument, e.g. STRING, BOOLEAN, etc.
+   */
+  getType() {
+    return this._type;
+  }
+
+  /**
+   * @returns {ArgumentType} The type of the elements of an array argument.
+   */
+  getItemType() {
+    return this._itemType;
+  }
+
+  /**
+   * @returns {string} The description of the argument.
+   */
+  getDescription() {
+    return this._description
+  }
+
+  /**
+   * @returns {boolean} A boolean indicating if the argument is required.
+   */
+  isRequired() {
+    return !!this._isRequired;
+  }
+
+  /**
+   * @returns {string|boolean|number} Optional, a default value for the argument. 
+   */
+  defaultValue() {
+    return this._defaultValue;
+  }
+}
+module.exports = { ArgumentMetadata, ArgumentType };

--- a/src/pagebuilder/jambo.json
+++ b/src/pagebuilder/jambo.json
@@ -1,0 +1,5 @@
+{
+  "dirs": {
+    "output": "public"
+  }
+}

--- a/src/pagebuilder/models/VerticalPageConfig.ts
+++ b/src/pagebuilder/models/VerticalPageConfig.ts
@@ -1,3 +1,5 @@
+import { EnumOrLiteral } from "@yext/answers-headless-react";
+import { CardTypes } from "../templates/componentRegistry";
 import { SortingConfig } from "./SortingConfig";
 
 export interface VerticalPageConfigs {
@@ -9,6 +11,6 @@ export interface VerticalPageConfig {
   path?: string,
   sorting?: SortingConfig,
   cardConfig?: {
-    cardName?: "STANDARD" | "PRODUCT" | "ACCORDIAN" | "LOCATION"
+    cardName?: EnumOrLiteral<CardTypes>
   }
 }

--- a/src/pagebuilder/pageBuilderAnswersAppConfig.ts
+++ b/src/pagebuilder/pageBuilderAnswersAppConfig.ts
@@ -20,28 +20,28 @@ const pageBuilderAnswersAppConfig: AnswersAppConfig = {
       label: 'FAQS',
       path: '/faqs',
       cardConfig: {
-        cardName: 'STANDARD'
+        cardName: 'Standard'
       }
     },
     events: {
       label: 'Event',
       path: '/events',
       cardConfig: {
-        cardName: 'STANDARD'
+        cardName: 'Standard'
       }
     },
     locations: {
       label: 'Locations',
       path: '/locations',
       cardConfig: {
-        cardName: 'STANDARD'
+        cardName: 'Standard'
       }
     },
     jobs: {
       label: 'Jobs',
       path: '/jobs',
       cardConfig: {
-        cardName: 'STANDARD'
+        cardName: 'Standard'
       }
     },
   }

--- a/src/pagebuilder/templates/componentRegistry.ts
+++ b/src/pagebuilder/templates/componentRegistry.ts
@@ -1,9 +1,13 @@
 import { StandardCard } from "../../components/cards/StandardCard";
 import { CardComponent } from "../../models/cardComponent";
 
+export enum CardTypes {
+  Standard = 'Standard'
+}
+
 /**
  * Map card name to the corresponding React component.
  */
-export const CardNameToComponentMap: Record<string, CardComponent> = {
-  'STANDARD': StandardCard
+export const CardRegistry: Record<string, CardComponent> = {
+  [CardTypes.Standard]: StandardCard
 }


### PR DESCRIPTION
This pr add the ability to add and use custom card component

- add a jambo command to create custom card component
   - command requires the new card component's name and the card template's file path.
   - will create a new component file in 'cards' directory and update card registry to include the new component
- Adjust typescript interfaces to support custom card component. Previously we intend to construct a union of all card component props when defining what a card config should be. Now that configuration interface is switch to Record<string, unknown> to support any props from custom card component.

J=SLAP-1807
TEST=manual

- in /pagebuilder folder, ran `npx jambo card --name RandomCard --cardTemplateFilePath ../components/cards/StandardCard.tsx` and see 'RandomCard.tsx' is created properly and content in 'componentRegistry.ts' is updated properly
- ran commands with wrong param values and see the right error is thrown