### PR TITLE
Fix css composition method in Facets

### DIFF
--- a/src/components/Facet.tsx
+++ b/src/components/Facet.tsx
@@ -90,7 +90,7 @@ export default function Facet(props: FacetProps): JSX.Element {
               option: { id: option.displayName, label: `${option.displayName} (${option.count})` },
               onClick: () => onToggle(facet.fieldId, option),
               selected: option.selected,
-              customCssClasses: cssClasses
+              cssClasses
             })
           )}
         </div>

--- a/src/components/Facet.tsx
+++ b/src/components/Facet.tsx
@@ -2,7 +2,10 @@ import { useAnswersUtilities, DisplayableFacet, DisplayableFacetOption } from '@
 import { useState } from 'react';
 import useCollapse from 'react-collapsed';
 import { CompositionMethod, useComposedCssClasses } from '../hooks/useComposedCssClasses';
-import renderCheckboxOption, { CheckboxOptionCssClasses } from './utils/renderCheckboxOption';
+import renderCheckboxOption, {
+  CheckboxOptionCssClasses,
+  builtInCssClasses as builtInCheckboxOptionCssClasses
+} from './utils/renderCheckboxOption';
 import { ReactComponent as DropdownIcon } from '../icons/chevron.svg';
 
 export type onFacetChangeFn = (fieldId: string, option: DisplayableFacetOption) => void
@@ -31,6 +34,7 @@ export interface FacetCssClasses extends CheckboxOptionCssClasses {
 }
 
 const builtInCssClasses: FacetCssClasses = {
+  ...builtInCheckboxOptionCssClasses,
   label: 'text-gray-900 text-sm font-medium text-left',
   labelIcon: 'w-3',
   labelContainer: 'w-full flex justify-between items-center mb-4',

--- a/src/components/Facet.tsx
+++ b/src/components/Facet.tsx
@@ -18,7 +18,7 @@ export interface FacetConfig {
 interface FacetProps extends FacetConfig {
   facet: DisplayableFacet,
   onToggle: onFacetChangeFn,
-  customCssclasses?: FacetCssClasses,
+  customCssClasses?: FacetCssClasses,
   cssCompositionMethod?: CompositionMethod
 }
 
@@ -46,10 +46,10 @@ export default function Facet(props: FacetProps): JSX.Element {
     defaultExpanded,
     label,
     placeholderText='Search here...',
-    customCssclasses,
+    customCssClasses,
     cssCompositionMethod 
   } = props;
-  const cssClasses = useComposedCssClasses(builtInCssClasses, customCssclasses, cssCompositionMethod);
+  const cssClasses = useComposedCssClasses(builtInCssClasses, customCssClasses, cssCompositionMethod);
   const answersUtilities = useAnswersUtilities();
   const hasSelectedFacet = !!facet.options.find(o => o.selected);
   const [ filterValue, setFilterValue ] = useState('');

--- a/src/components/Facet.tsx
+++ b/src/components/Facet.tsx
@@ -85,7 +85,8 @@ export default function Facet(props: FacetProps): JSX.Element {
             renderCheckboxOption({
               option: { id: option.displayName, label: `${option.displayName} (${option.count})` },
               onClick: () => onToggle(facet.fieldId, option),
-              selected: option.selected
+              selected: option.selected,
+              customCssClasses: cssClasses
             })
           )}
         </div>

--- a/src/components/Facets.tsx
+++ b/src/components/Facets.tsx
@@ -75,7 +75,7 @@ export default function Facets (props: FacetsProps): JSX.Element {
           <Facet
             facet={facet}
             {...config}
-            customCssclasses={cssClasses}
+            customCssClasses={cssClasses}
             cssCompositionMethod={cssCompositionMethod}
             onToggle={handleFacetOptionChange} />
           {!isLastFacet && <Divider customCssClasses={{ divider: cssClasses.divider }} cssCompositionMethod='replace'/>}

--- a/src/components/Facets.tsx
+++ b/src/components/Facets.tsx
@@ -76,6 +76,7 @@ export default function Facets (props: FacetsProps): JSX.Element {
             facet={facet}
             {...config}
             customCssclasses={cssClasses}
+            cssCompositionMethod={cssCompositionMethod}
             onToggle={handleFacetOptionChange} />
           {!isLastFacet && <Divider customCssClasses={{ divider: cssClasses.divider }} cssCompositionMethod='replace'/>}
         </div>

--- a/src/components/StaticFilters.tsx
+++ b/src/components/StaticFilters.tsx
@@ -77,7 +77,7 @@ export default function StaticFilters(props: StaticFiltersProps): JSX.Element {
                 option: { id: `${index}`, label: option.label },
                 onClick: selected => handleFilterOptionChange(filter, selected),
                 selected: getOptionSelectStatus(option),
-                customCssClasses: cssClasses
+                cssClasses
               });
             }
             )}

--- a/src/components/StaticFilters.tsx
+++ b/src/components/StaticFilters.tsx
@@ -72,7 +72,8 @@ export default function StaticFilters(props: StaticFiltersProps): JSX.Element {
               return renderCheckboxOption({
                 option: { id: `${index}`, label: option.label },
                 onClick: selected => handleFilterOptionChange(filter, selected),
-                selected: getOptionSelectStatus(option)
+                selected: getOptionSelectStatus(option),
+                customCssClasses: cssClasses
               });
             }
             )}

--- a/src/components/StaticFilters.tsx
+++ b/src/components/StaticFilters.tsx
@@ -1,7 +1,10 @@
 import { useAnswersActions, useAnswersState, Filter, Matcher } from '@yext/answers-headless-react';
 import { CompositionMethod, useComposedCssClasses } from '../hooks/useComposedCssClasses';
 import { isDuplicateFilter } from '../utils/filterutils';
-import renderCheckboxOption, { CheckboxOptionCssClasses } from './utils/renderCheckboxOption';
+import renderCheckboxOption, {
+  CheckboxOptionCssClasses,
+  builtInCssClasses as builtInCheckboxOptionCssClasses
+} from './utils/renderCheckboxOption';
 
 interface FilterOption {
   fieldId: string,
@@ -26,6 +29,7 @@ interface StaticFiltersCssClasses extends CheckboxOptionCssClasses {
 }
 
 const builtInCssClasses: StaticFiltersCssClasses = {
+  ...builtInCheckboxOptionCssClasses,
   container: 'md:w-40',
   title: 'text-gray-900 text-sm font-medium mb-4',
   optionsContainer: 'flex flex-col space-y-3'

--- a/src/components/utils/renderCheckboxOption.tsx
+++ b/src/components/utils/renderCheckboxOption.tsx
@@ -13,7 +13,7 @@ interface CheckBoxOptionProps {
   option: CheckboxOption,
   onClick: (isChecked: boolean) => void,
   selected?: boolean,
-  customCssClasses?: CheckboxOptionCssClasses
+  cssClasses?: CheckboxOptionCssClasses
 }
 
 export const builtInCssClasses: CheckboxOptionCssClasses = {
@@ -23,18 +23,18 @@ export const builtInCssClasses: CheckboxOptionCssClasses = {
 }
 
 export default function renderCheckboxOption({
-  option, selected, onClick, customCssClasses = {}
+  option, selected, onClick, cssClasses = {}
 }: CheckBoxOptionProps) {
   return (
-    <div className={customCssClasses.option} key={option.id}>
+    <div className={cssClasses.option} key={option.id}>
       <input 
         type="checkbox"
         id={option.id}
         checked={selected}
-        className={customCssClasses.optionInput}
+        className={cssClasses.optionInput}
         onChange={evt => onClick(evt.target.checked)}
       />
-      <label className={customCssClasses.optionLabel} htmlFor={option.id}>{option.label}</label>
+      <label className={cssClasses.optionLabel} htmlFor={option.id}>{option.label}</label>
     </div>
   );
 }

--- a/src/components/utils/renderCheckboxOption.tsx
+++ b/src/components/utils/renderCheckboxOption.tsx
@@ -16,26 +16,25 @@ interface CheckBoxOptionProps {
   customCssClasses?: CheckboxOptionCssClasses
 }
 
-const builtInCssClasses: CheckboxOptionCssClasses = {
+export const builtInCssClasses: CheckboxOptionCssClasses = {
   option: 'flex items-center space-x-3',
   optionInput: 'w-3.5 h-3.5 form-checkbox cursor-pointer border border-gray-300 rounded-sm text-blue-600 focus:ring-blue-500',
   optionLabel: 'text-gray-500 text-sm font-normal cursor-pointer'
 }
 
 export default function renderCheckboxOption({
-  option, selected, onClick, customCssClasses
+  option, selected, onClick, customCssClasses = {}
 }: CheckBoxOptionProps) {
-  const cssClasses = { ...builtInCssClasses, ...customCssClasses };
   return (
-    <div className={cssClasses.option} key={option.id}>
+    <div className={customCssClasses.option} key={option.id}>
       <input 
         type="checkbox"
         id={option.id}
         checked={selected}
-        className={cssClasses.optionInput}
+        className={customCssClasses.optionInput}
         onChange={evt => onClick(evt.target.checked)}
       />
-      <label className={cssClasses.optionLabel} htmlFor={option.id}>{option.label}</label>
+      <label className={customCssClasses.optionLabel} htmlFor={option.id}>{option.label}</label>
     </div>
   );
 }


### PR DESCRIPTION
- ensures that cssCompositionsMethod specified in Facets is also pass to individual Facet component
- update renderCheckboxOption to directly is the cssClasses props. Parent component built-in css should combine with builtin checkboxOption css to take advantage of the parent component's cssCompositionMethod before passing into renderCheckboxOption

J=none
TEST=manual

pass in customCssClasses with `label` field and cssCompositionMethod, see that Facet label styling appear as expected