### PR TITLE
Minor changes for searchbar's entity preview and key nav logic

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -265,6 +265,9 @@ export default function SearchBar({
             autocompletePromiseRef.current = executeAutocomplete()
           }
         }}
+        onFocusItem={query => {
+          updateEntityPreviews(query || '');
+        }}
       >
         <div className={cssClasses?.inputContainer}>
           <div className={cssClasses.logoContainer}>


### PR DESCRIPTION
- add `onFocusItem` to update entity previews when user navigate through the autocomplete options.
- when a page is loaded with initial query, update `LastTypedOrSubmittedValue` to be query to parentQuery for key nav to work

J=SLAP-1847
TEST=manual

- navigate through autocomplete options and see entity preview render
- go to a page with initial query, and see that pressing up/down arrow would update search bar and highlight the option
