### PR TITLE
Entity preview navigation

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -27,7 +27,6 @@ export default function Dropdown(props: PropsWithChildren<{
   parentQuery?: string,
   onSelect?: (value: string, index: number, focusedItemData: Record<string, unknown> | undefined) => void,
   onToggle?: (isActive: boolean, value: string) => void,
-  onFocusItem?: (query: string | undefined) => void,
   className?: string,
   activeClassName?: string
 }>) {
@@ -38,7 +37,6 @@ export default function Dropdown(props: PropsWithChildren<{
     initialValue,
     onSelect,
     onToggle,
-    onFocusItem,
     className,
     activeClassName,
     parentQuery,
@@ -51,7 +49,7 @@ export default function Dropdown(props: PropsWithChildren<{
   const inputContext = useInputContextInstance(initialValue);
   const { value, setValue, lastTypedOrSubmittedValue, setLastTypedOrSubmittedValue } = inputContext;
 
-  const focusContext = useFocusContextInstance(items, lastTypedOrSubmittedValue, setValue, onFocusItem);
+  const focusContext = useFocusContextInstance(items, lastTypedOrSubmittedValue, setValue);
   const { focusedIndex, updateFocusedItem } = focusContext;
 
   const dropdownContext = useDropdownContextInstance(value, screenReaderUUID, onToggle, onSelect);
@@ -116,8 +114,7 @@ function useInputContextInstance(initialValue = ''): InputContextType {
 function useFocusContextInstance(
   items: DropdownItemData[],
   lastTypedOrSubmittedValue: string,
-  setValue: (newValue: string) => void,
-  onFocusItem?: (value: string | undefined) => void,
+  setValue: (newValue: string) => void
 ): FocusContextType {
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const [focusedValue, setFocusedValue] = useState<string | null>(null);
@@ -142,7 +139,6 @@ function useFocusContextInstance(
     }
     setFocusedValue(updatedValue);
     setValue(updatedValue);
-    onFocusItem?.(updatedValue);
   }
 
   return {

--- a/src/components/Dropdown/DropdownInput.tsx
+++ b/src/components/Dropdown/DropdownInput.tsx
@@ -72,6 +72,7 @@ export default function DropdownInput(props: {
       onChange={handleChange}
       onKeyDown={handleKeyDown}
       onFocus={handleFocus}
+      id={screenReaderUUID && generateDropdownId(screenReaderUUID, -1)}
       aria-describedby={screenReaderUUID}
       aria-activedescendant={screenReaderUUID && generateDropdownId(screenReaderUUID, focusedIndex)}
     />

--- a/src/components/SampleVisualSearchBar.tsx
+++ b/src/components/SampleVisualSearchBar.tsx
@@ -5,6 +5,7 @@ import { universalResultsConfig } from '../config/universalResultsConfig';
 import { ReactComponent as EventIcon } from '../icons/event.svg';
 import { ReactComponent as FAQIcon } from '../icons/faq.svg';
 import renderHighlightedValue from './utils/renderHighlightedValue';
+import DropdownItem from './Dropdown/DropdownItem';
 
 /**
  * This is an example of how to use the VisualSearchBar component.
@@ -15,13 +16,24 @@ export default function SampleVisualSearchBar() {
       placeholder='Search...'
       entityPreviewsDebouncingTime={100}
       verticalKeyToLabel={verticalKey => universalResultsConfig[verticalKey]?.label ?? verticalKey}
-      renderEntityPreviews={isLoading => (
+      renderEntityPreviews={(isLoading, _results, onSubmit) => (
         <div className={isLoading ? 'opacity-50' : ''}>
           <EntityPreviews verticalKey='events'>
             {results => (<>
               {results.length > 0 && <div className='h-px bg-gray-200 mt-1 mb-4 mx-3.5'></div>}
               <div className='grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-4 mx-3.5 mt-1'>
-                {results.map((r, index) => <EventCard result={r} key={`${index}-${r.name}`} />)}
+                {results.map((r, index) =>
+                  <DropdownItem
+                    key={index}
+                    className='hover:bg-gray-100 cursor-pointer'
+                    focusedClassName='bg-gray-100'
+                    value={r.name || ''}
+                    itemData={{ verticalLink: `/events?query=${r.name}` }}
+                    onClick={onSubmit}
+                  >
+                    <EventCard result={r} key={`${index}-${r.name}`} />
+                  </DropdownItem>
+                )}
               </div>
             </>
             )}
@@ -29,7 +41,18 @@ export default function SampleVisualSearchBar() {
           <EntityPreviews verticalKey='faqs' limit={2}>
             {results => (
               <div className='flex flex-col'>
-                {results.map((r, index) => <FaqCard result={r} key={`${index}-${r.name}`} />)}
+                {results.map((r, index) =>
+                  <DropdownItem
+                    key={index}
+                    className='hover:bg-gray-100 cursor-pointer'
+                    focusedClassName='bg-gray-100'
+                    value={r.name || ''}
+                    itemData={{ verticalLink: `/faqs?query=${r.name}` }}
+                    onClick={onSubmit}
+                  >
+                    <FaqCard result={r} key={`${index}-${r.name}`} />
+                  </DropdownItem>
+                )}
               </div>
             )}
           </EntityPreviews>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -284,6 +284,13 @@ export default function SearchBar({
         activeClassName={activeClassName}
         screenReaderText={screenReaderText}
         parentQuery={query}
+        onToggle={(isActive, value = '') => {
+          if (!isActive) {
+            updateEntityPreviews(value);
+            answersActions.setQuery(value);
+            autocompletePromiseRef.current = executeAutocomplete();
+          }
+        }}
       >
         <div className={cssClasses?.inputContainer}>
           <div className={cssClasses.logoContainer}>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -38,9 +38,8 @@ const builtInCssClasses: SearchBarCssClasses = {
   inputElement: 'outline-none flex-grow border-none h-full pl-0.5 pr-2',
   logoContainer: 'w-7 mx-2.5 my-2',
   optionContainer: 'flex items-stretch py-1.5 px-3.5 cursor-pointer hover:bg-gray-100',
-  resultIconContainer: 'opacity-20 w-7 h-7 pl-1 mr-4',
   searchButtonContainer: ' w-8 h-full mx-2 flex flex-col justify-center items-center',
-  submitButton: 'h-7 w-7',
+  searchButton: 'h-7 w-7',
   focusedOption: 'bg-gray-100',
   clearButton: 'mr-3.5 cursor-pointer',
   verticalDivider: 'mr-0.5',
@@ -54,33 +53,31 @@ const builtInCssClasses: SearchBarCssClasses = {
 
 export interface SearchBarCssClasses extends AutocompleteResultCssClasses {
   container?: string,
-  inputDropdownContainer?: string,
-  inputDropdownContainer___active?: string,
-  resultIconContainer?: string,
-  submitButton?: string,
-  dropdownContainer?: string,
   inputElement?: string,
   inputContainer?: string,
+  inputDropdownContainer?: string,
+  inputDropdownContainer___active?: string,
+  clearButton?: string,
+  searchButton?: string,
+  searchButtonContainer?: string,
+  dropdownContainer?: string,
   divider?: string,
   logoContainer?: string,
-  searchButtonContainer?: string,
-  sectionContainer?: string,
-  sectionLabel?: string,
-  optionsContainer?: string,
   optionContainer?: string,
+  optionIcon?: string,
   focusedOption?: string,
   recentSearchesOptionContainer?: string,
   recentSearchesIcon?: string,
   recentSearchesOption?: string,
   recentSearchesNonHighlighted?: string,
   verticalLink?: string,
-  clearButton?: string,
   verticalDivider?: string
 }
 
 type RenderEntityPreviews = (
   autocompleteLoading: boolean,
-  verticalResultsArray: VerticalResults[]
+  verticalResultsArray: VerticalResults[],
+  onSubmit: (value: string, _index: number, itemData?: FocusedItemData) => void
 ) => JSX.Element;
 
 interface Props {
@@ -147,18 +144,6 @@ export default function SearchBar({
     executeQueryWithNearMeHandling();
   }
 
-  const [entityPreviewsState, executeEntityPreviewsQuery] = useEntityPreviews(entityPreviewsDebouncingTime);
-  const { verticalResultsArray, isLoading: entityPreviewsLoading } = entityPreviewsState;
-  const entityPreviews = renderEntityPreviews && renderEntityPreviews(entityPreviewsLoading, verticalResultsArray);
-  function updateEntityPreviews(query: string) {
-    if (!renderEntityPreviews) {
-      return;
-    }
-    const restrictVerticals = calculateRestrictVerticals(entityPreviews);
-    const universalLimit = calculateUniversalLimit(entityPreviews);
-    executeEntityPreviewsQuery(query, universalLimit, restrictVerticals);
-  }
-
   const handleSubmit = (value: string, _index: number, itemData?: FocusedItemData) => {
     answersActions.setQuery(value || '');
     if (itemData && typeof itemData.verticalLink === 'string') {
@@ -168,6 +153,18 @@ export default function SearchBar({
     } else {
       executeQuery();
     }
+  }
+
+  const [entityPreviewsState, executeEntityPreviewsQuery] = useEntityPreviews(entityPreviewsDebouncingTime);
+  const { verticalResultsArray, isLoading: entityPreviewsLoading } = entityPreviewsState;
+  const entityPreviews = renderEntityPreviews && renderEntityPreviews(entityPreviewsLoading, verticalResultsArray, handleSubmit);
+  function updateEntityPreviews(query: string) {
+    if (!renderEntityPreviews) {
+      return;
+    }
+    const restrictVerticals = calculateRestrictVerticals(entityPreviews);
+    const universalLimit = calculateUniversalLimit(entityPreviews);
+    executeEntityPreviewsQuery(query, universalLimit, restrictVerticals);
   }
 
   function renderInput() {
@@ -228,7 +225,12 @@ export default function SearchBar({
           value={result.value}
           onClick={handleSubmit}
         >
-          {renderAutocompleteResult(result, cssClasses, MagnifyingGlassIcon, `autocomplete option: ${result.value}`)}
+          {renderAutocompleteResult(
+            result,
+            { ...cssClasses, icon: cssClasses.optionIcon },
+            MagnifyingGlassIcon,
+            `autocomplete option: ${result.value}`
+          )}
         </DropdownItem>
         {!hideVerticalLinks && !isVertical && result.verticalKeys?.map((verticalKey, j) => (
           <DropdownItem
@@ -282,16 +284,6 @@ export default function SearchBar({
         activeClassName={activeClassName}
         screenReaderText={screenReaderText}
         parentQuery={query}
-        onToggle={(isActive, value = '') => {
-          if (!isActive) {
-            updateEntityPreviews(value);
-            answersActions.setQuery(value);
-            autocompletePromiseRef.current = executeAutocomplete()
-          }
-        }}
-        onFocusItem={query => {
-          updateEntityPreviews(query || '');
-        }}
       >
         <div className={cssClasses?.inputContainer}>
           <div className={cssClasses.logoContainer}>
@@ -321,20 +313,14 @@ export default function SearchBar({
 function StyledDropdownMenu({ cssClasses, children }: PropsWithChildren<{
   cssClasses: {
     divider?: string,
-    dropdownContainer?: string,
-    sectionContainer?: string,
-    optionsContainer?: string
+    dropdownContainer?: string
   }
 }>) {
   return (
     <DropdownMenu>
       <div className={cssClasses.divider} />
       <div className={cssClasses.dropdownContainer}>
-        <div className={cssClasses.sectionContainer}>
-          <div className={cssClasses.optionsContainer}>
-            {children}
-          </div>
-        </div>
+        {children}
       </div>
     </DropdownMenu>
   )
@@ -361,14 +347,14 @@ function DropdownSearchButton({ executeQuery, isLoading, cssClasses }: {
   isLoading: boolean,
   cssClasses: {
     searchButtonContainer?: string,
-    submitButton?: string
+    searchButton?: string
   }
 }) {
   const { toggleDropdown } = useDropdownContext();
   return (
     <div className={cssClasses.searchButtonContainer}>
       <SearchButton
-        className={cssClasses.submitButton}
+        className={cssClasses.searchButton}
         handleClick={() => {
           executeQuery();
           toggleDropdown(false);


### PR DESCRIPTION
Add entity preview navigation

expected behavior after discussion with product:
- update entity previews based on whatever user typed. Remain static when user navigate through autocomplete options.
- hitting down arrow should give you access to said entity previews, and when you reach the end you loop back to the top

Changes:
- update EntityPreviews' children in SampleVisualSearchBar to encapsulate the card with DropdownItem component so it can be navigable. Modify renderEntityPreviews to pass in a default onSubmit for when user click on entity preview item.
- update useSynchronizedRequest to check for component mount state before calling any set state.
- some cleanup for SearchBar css interface
- also fix existing wcag issues. By default, the focus element id (for aria-activedescendant) should point to input element. Add id to input element would get rid of the `aria-valid-attr-value` wcag problem

J=SLAP-1793
TEST=manual

- type arlington/covid, and see the corresponding entity preview of faq card and event card shows up.
- press arrow down through the dropdown, see that I can navigate to entity previews and loop back up at the end.
- See that clicking/entering on an entity preview execute query and bring to the corresponding vertical page.