### PR TITLE
Serve on Yext Sites

### DIFF
--- a/sites-config/ci_config.json
+++ b/sites-config/ci_config.json
@@ -9,11 +9,11 @@
   },
   "baseImageTag": "node-17",
   "dependencies": {
-      "installDepsCmd": "echo npm install",
+      "installDepsCmd": "npm ci",
       "requiredFiles": []
   },
   "buildArtifacts": {
-      "buildSetupCmd": "npm install",
+      "buildSetupCmd": "npm ci",
       "buildCmd": "npm run build"
   },
   "livePreview": {

--- a/sites-config/ci_config.json
+++ b/sites-config/ci_config.json
@@ -9,11 +9,11 @@
   },
   "baseImageTag": "node-17",
   "dependencies": {
-      "installDepsCmd": "npm install",
-      "requiredFiles": []
+      "installDepsCmd": "npm ci",
+      "requiredFiles": ["package.json"]
   },
   "buildArtifacts": {
-      "buildSetupCmd": "npm install",
+      "buildSetupCmd": "npm ci",
       "buildCmd": "npm run build"
   },
   "livePreview": {

--- a/sites-config/ci_config.json
+++ b/sites-config/ci_config.json
@@ -13,7 +13,7 @@
       "requiredFiles": []
   },
   "buildArtifacts": {
-      "build_setup_cmd": "echo build setup cmd",
+      "build_setup_cmd": "npm install",
       "build_cmd": "npm run build"
   },
   "livePreview": {

--- a/sites-config/ci_config.json
+++ b/sites-config/ci_config.json
@@ -17,6 +17,6 @@
       "buildCmd": "npm run build"
   },
   "livePreview": {
-      "serveCmd": "PORT=8080 && npm run start"
+      "serveCmd": "PORT=8080 npm run start"
   }
 }

--- a/sites-config/ci_config.json
+++ b/sites-config/ci_config.json
@@ -17,8 +17,6 @@
       "buildCmd": "npm run build"
   },
   "livePreview": {
-      "serveSetupCmd": "echo serve setup cmd",
       "serveCmd": "export PORT=8080 && npm run start"
-  },
-  "watchCmd": "echo watch cmd"
+  }
 }

--- a/sites-config/ci_config.json
+++ b/sites-config/ci_config.json
@@ -1,0 +1,24 @@
+{
+  "artifactStructure": {
+      "assets": [
+          {
+              "root": "test-site/public"
+          }
+      ],
+      "hbsTemplates": []
+  },
+  "base_image_tag": "node-14",
+  "dependencies": {
+      "installDepsCmd": "npm install",
+      "requiredFiles": []
+  },
+  "buildArtifacts": {
+      "build_setup_cmd": "npm install",
+      "build_cmd": "npm run build"
+  },
+  "livePreview": {
+      "serve_setup_cmd": "echo serve setup cmd",
+      "serve_cmd": "npm run start"
+  },
+  "watch_cmd": "npm run watch"
+}

--- a/sites-config/ci_config.json
+++ b/sites-config/ci_config.json
@@ -1,22 +1,22 @@
 {
-  "artifactStructure": {
-      "assets": [
-          {
-              "root": "build"
-          }
-      ],
-      "hbsTemplates": []
-  },
-  "baseImageTag": "node-17",
-  "dependencies": {
-      "installDepsCmd": "npm install",
-      "requiredFiles": []
-  },
-  "buildArtifacts": {
-      "buildSetupCmd": "npm ci",
-      "buildCmd": "npm run build"
-  },
-  "livePreview": {
-      "serveCmd": "PORT=8080 npm run start"
-  }
+    "artifactStructure": {
+        "assets": [
+            {
+                "root": "build"
+            }
+        ],
+        "hbsTemplates": []
+    },
+    "baseImageTag": "node-17",
+    "dependencies": {
+        "installDepsCmd": "npm install",
+        "requiredFiles": []
+    },
+    "buildArtifacts": {
+        "buildSetupCmd": "npm ci",
+        "buildCmd": "npm run build"
+    },
+    "livePreview": {
+        "serveCmd": "PORT=8080 npm run start"
+    }
 }

--- a/sites-config/ci_config.json
+++ b/sites-config/ci_config.json
@@ -20,5 +20,5 @@
       "serve_setup_cmd": "echo serve setup cmd",
       "serve_cmd": "export PORT=8080 && npm run start"
   },
-  "watch_cmd": "echo npm run watch"
+  "watch_cmd": "echo watch cmd"
 }

--- a/sites-config/ci_config.json
+++ b/sites-config/ci_config.json
@@ -7,18 +7,18 @@
       ],
       "hbsTemplates": []
   },
-  "base_image_tag": "node-17",
+  "baseImageTag": "node-17",
   "dependencies": {
       "installDepsCmd": "npm install",
       "requiredFiles": []
   },
   "buildArtifacts": {
-      "build_setup_cmd": "npm install",
-      "build_cmd": "npm run build"
+      "buildSetupCmd": "npm install",
+      "buildCmd": "npm run build"
   },
   "livePreview": {
-      "serve_setup_cmd": "echo serve setup cmd",
-      "serve_cmd": "export PORT=8080 && npm run start"
+      "serveSetupCmd": "echo serve setup cmd",
+      "serveCmd": "export PORT=8080 && npm run start"
   },
-  "watch_cmd": "echo watch cmd"
+  "watchCmd": "echo watch cmd"
 }

--- a/sites-config/ci_config.json
+++ b/sites-config/ci_config.json
@@ -9,8 +9,8 @@
   },
   "baseImageTag": "node-17",
   "dependencies": {
-      "installDepsCmd": "npm ci",
-      "requiredFiles": ["package.json"]
+      "installDepsCmd": "npm install",
+      "requiredFiles": ["package.json", "package-lock.json"]
   },
   "buildArtifacts": {
       "buildSetupCmd": "npm ci",

--- a/sites-config/ci_config.json
+++ b/sites-config/ci_config.json
@@ -17,6 +17,6 @@
       "buildCmd": "npm run build"
   },
   "livePreview": {
-      "serveCmd": "export PORT=8080 && npm run start"
+      "serveCmd": "PORT=8080 && npm run start"
   }
 }

--- a/sites-config/ci_config.json
+++ b/sites-config/ci_config.json
@@ -9,11 +9,11 @@
   },
   "baseImageTag": "node-17",
   "dependencies": {
-      "installDepsCmd": "npm ci",
+      "installDepsCmd": "npm install",
       "requiredFiles": []
   },
   "buildArtifacts": {
-      "buildSetupCmd": "npm ci",
+      "buildSetupCmd": "npm install",
       "buildCmd": "npm run build"
   },
   "livePreview": {

--- a/sites-config/ci_config.json
+++ b/sites-config/ci_config.json
@@ -9,7 +9,7 @@
   },
   "baseImageTag": "node-17",
   "dependencies": {
-      "installDepsCmd": "npm install",
+      "installDepsCmd": "echo npm install",
       "requiredFiles": []
   },
   "buildArtifacts": {

--- a/sites-config/ci_config.json
+++ b/sites-config/ci_config.json
@@ -2,7 +2,7 @@
   "artifactStructure": {
       "assets": [
           {
-              "root": "test-site/public"
+              "root": "build"
           }
       ],
       "hbsTemplates": []
@@ -18,7 +18,7 @@
   },
   "livePreview": {
       "serve_setup_cmd": "echo serve setup cmd",
-      "serve_cmd": "npm run start"
+      "serve_cmd": "export PORT=8080 && npm run start"
   },
   "watch_cmd": "npm run watch"
 }

--- a/sites-config/ci_config.json
+++ b/sites-config/ci_config.json
@@ -20,5 +20,5 @@
       "serve_setup_cmd": "echo serve setup cmd",
       "serve_cmd": "export PORT=8080 && npm run start"
   },
-  "watch_cmd": "npm run watch"
+  "watch_cmd": "echo npm run watch"
 }

--- a/sites-config/ci_config.json
+++ b/sites-config/ci_config.json
@@ -7,13 +7,13 @@
       ],
       "hbsTemplates": []
   },
-  "base_image_tag": "node-14",
+  "base_image_tag": "node-17",
   "dependencies": {
       "installDepsCmd": "npm install",
       "requiredFiles": []
   },
   "buildArtifacts": {
-      "build_setup_cmd": "npm install",
+      "build_setup_cmd": "echo build setup cmd",
       "build_cmd": "npm run build"
   },
   "livePreview": {

--- a/sites-config/ci_config.json
+++ b/sites-config/ci_config.json
@@ -10,7 +10,7 @@
   "baseImageTag": "node-17",
   "dependencies": {
       "installDepsCmd": "npm install",
-      "requiredFiles": ["package.json", "package-lock.json"]
+      "requiredFiles": []
   },
   "buildArtifacts": {
       "buildSetupCmd": "npm ci",


### PR DESCRIPTION
Serve on yext sites

This adds default configuration to support yext sites. It works for both full production builds and for live preview. Currently the page is being served by the dev branch, but it will be available for develop and main once it's merged into those branches. I opted for `npm install` for the `installDepsCmd` so that the package.json file can be modified in live preview and the package-lock.json can be updated as necessary. For the `buildSetupCmd`, I went with `npm ci` because it's faster and ensures we get a clean build based purely on the package-lock.json file.

J=SLAP-1841
TEST=manual

Add the repo to yext sites and view the page being served at https://devyextsites-react--site--search--starter-slapshot-pagescdn-com.preview.pagescdn.com/. Also load the experience in the code editor and see the page work with live preview. Modify a file and see the file reflected in the page after refreshing the page