### PR TITLE
fix SearchBar autocomplete options flickering for certain cases

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -149,16 +149,6 @@ export default function SearchBar({
     executeQueryWithNearMeHandling();
   }
 
-  function updateDropdownOptionsAndQuery(value: string) {
-    answersActions.setQuery(value);
-    if (renderEntityPreviews) {
-      const restrictVerticals = calculateRestrictVerticals(entityPreviews);
-      const universalLimit = calculateUniversalLimit(entityPreviews);
-      executeEntityPreviewsQuery(value, universalLimit, restrictVerticals);
-    }
-    autocompletePromiseRef.current = executeAutocomplete();
-  }
-
   const handleSubmit = (value: string, _index: number, itemData?: FocusedItemData) => {
     answersActions.setQuery(value || '');
     if (itemData && typeof itemData.verticalLink === 'string') {
@@ -173,6 +163,16 @@ export default function SearchBar({
   const [entityPreviewsState, executeEntityPreviewsQuery] = useEntityPreviews(entityPreviewsDebouncingTime);
   const { verticalResultsArray, isLoading: entityPreviewsLoading } = entityPreviewsState;
   const entityPreviews = renderEntityPreviews && renderEntityPreviews(entityPreviewsLoading, verticalResultsArray, handleSubmit);
+
+  function updateDropdownOptionsAndQuery(value: string) {
+    answersActions.setQuery(value);
+    if (renderEntityPreviews) {
+      const restrictVerticals = calculateRestrictVerticals(entityPreviews);
+      const universalLimit = calculateUniversalLimit(entityPreviews);
+      executeEntityPreviewsQuery(value, universalLimit, restrictVerticals);
+    }
+    autocompletePromiseRef.current = executeAutocomplete();
+  }
 
   function renderInput() {
     return (

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -141,7 +141,7 @@ export default function SearchBar({
     autocompletePromiseRef.current = undefined;
   }
 
-  function handleQuery() {
+  function executeQuery() {
     if (!hideRecentSearches) {
       const input = answersActions.state.query.input;
       input && setRecentSearch(input);
@@ -156,7 +156,7 @@ export default function SearchBar({
         querySource: QuerySource.Autocomplete
       });
     } else {
-      handleQuery();
+      executeQuery();
     }
   }
 
@@ -266,7 +266,7 @@ export default function SearchBar({
           onClick={() => {
             updateEntityPreviews('');
             answersActions.setQuery('');
-            handleQuery();
+            executeQuery();
           }}
         >
           <CloseIcon />
@@ -302,7 +302,7 @@ export default function SearchBar({
           {renderInput()}
           {query && renderClearButton()}
           <DropdownSearchButton
-            handleQuery={handleQuery}
+            executeQuery={executeQuery}
             cssClasses={cssClasses}
             isLoading={isLoading}
           />
@@ -352,8 +352,8 @@ function getScreenReaderText(autocompleteOptions = 0, recentSearchesOptions = 0)
   return (recentSearchesText + ' ' + autocompleteText).trim();
 }
 
-function DropdownSearchButton({ handleQuery, isLoading, cssClasses }: {
-  handleQuery: () => void,
+function DropdownSearchButton({ executeQuery, isLoading, cssClasses }: {
+  executeQuery: () => void,
   isLoading: boolean,
   cssClasses: {
     searchButtonContainer?: string,
@@ -366,7 +366,7 @@ function DropdownSearchButton({ handleQuery, isLoading, cssClasses }: {
       <SearchButton
         className={cssClasses.searchButton}
         handleClick={() => {
-          handleQuery();
+          executeQuery();
           toggleDropdown(false);
         }}
         isLoading={isLoading}

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -164,14 +164,13 @@ export default function SearchBar({
   const { verticalResultsArray, isLoading: entityPreviewsLoading } = entityPreviewsState;
   const entityPreviews = renderEntityPreviews && renderEntityPreviews(entityPreviewsLoading, verticalResultsArray, handleSubmit);
 
-  function updateDropdownOptionsAndQuery(value: string) {
-    answersActions.setQuery(value);
-    if (renderEntityPreviews) {
-      const restrictVerticals = calculateRestrictVerticals(entityPreviews);
-      const universalLimit = calculateUniversalLimit(entityPreviews);
-      executeEntityPreviewsQuery(value, universalLimit, restrictVerticals);
+  function updateEntityPreviews(query: string) {
+    if (!renderEntityPreviews) {
+      return;
     }
-    autocompletePromiseRef.current = executeAutocomplete();
+    const restrictVerticals = calculateRestrictVerticals(entityPreviews);
+    const universalLimit = calculateUniversalLimit(entityPreviews);
+    executeEntityPreviewsQuery(query, universalLimit, restrictVerticals);
   }
 
   function renderInput() {
@@ -180,8 +179,16 @@ export default function SearchBar({
         className={cssClasses.inputElement}
         placeholder={placeholder}
         onSubmit={handleSubmit}
-        onFocus={updateDropdownOptionsAndQuery}
-        onChange={updateDropdownOptionsAndQuery}
+        onFocus={(value = '') => {
+          answersActions.setQuery(value);
+          updateEntityPreviews(value);
+          autocompletePromiseRef.current = executeAutocomplete()
+        }}
+        onChange={(value = '') => {
+          answersActions.setQuery(value);
+          updateEntityPreviews(value);
+          autocompletePromiseRef.current = executeAutocomplete();
+        }}
       />
     );
   }
@@ -257,7 +264,8 @@ export default function SearchBar({
           aria-label='Clear the search bar'
           className={cssClasses.clearButton}
           onClick={() => {
-            updateDropdownOptionsAndQuery('');
+            updateEntityPreviews('');
+            answersActions.setQuery('');
             handleQuery();
           }}
         >

--- a/src/hooks/useSynchronizedRequest.tsx
+++ b/src/hooks/useSynchronizedRequest.tsx
@@ -13,12 +13,14 @@ export function useSynchronizedRequest<RequestDataType, ResponseType>(
   executeRequest: (data?: RequestDataType) => Promise<ResponseType | undefined>
 ): [
     ResponseType | undefined,
-    (data?: RequestDataType) => Promise<ResponseType | undefined>
+    (data?: RequestDataType) => Promise<ResponseType | undefined>,
+    () => void
   ]
 {
   const isMountedRef = useComponentMountStatus();
   const networkIds = useRef({ latestRequest: 0, responseInState: 0 });
   const [synchronizedResponse, setSynchronizedResponse] = useState<ResponseType>();
+
   async function executeSynchronizedRequest (data?: RequestDataType): Promise<ResponseType | undefined> {
     const requestId = ++networkIds.current.latestRequest;
     return new Promise(async (resolve) => {
@@ -37,5 +39,10 @@ export function useSynchronizedRequest<RequestDataType, ResponseType>(
       resolve(response);
     });
   }
-  return [synchronizedResponse, executeSynchronizedRequest]
+  
+  function clearResponseData() {
+    setSynchronizedResponse(undefined);
+  }
+
+  return [synchronizedResponse, executeSynchronizedRequest, clearResponseData]
 };


### PR DESCRIPTION
updates SearchBar to clear the autocomplete whenever the dropdown closes, in order to remove stale autocomplete response data.

J=SLAP-1859
TEST=manual

autocomplete options no longer flicker
steps:
1. type "c" into search bar
2. either click on the "cawfee" autocomplete option, or submit it with the arrow keys + enter
3. click the search bar again, displays autocomplete options for "cawfee" and not "c" with no flickering
previously, would first briefly display the options for "c" before quickly changing to the options for "cawfee"

see that vertical links don't flicker, using the "locations" query and then selecting "locations that take mastercard and offer free wifi" `in Locations`