### PR TITLE
fix navigation styling from tailwind 2->3 upgrade

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -11,32 +11,40 @@ interface NavigationCssClasses {
   menuWrapper?: string,
   navLinkContainer?: string,
   navLinkContainer___active?: string,
+  navLinkContainer___inActive?: string,
   navLink?: string,
   kebabIcon?: string,
   menuButton?: string,
   menuButtonContainer?: string,
-  menuButton___menuOpen?: string,
+  menuButton___menuOpenNoActiveLink?: string,
+  menuButton___menuOpenHasActiveLink?: string,
   menuButton___hasActiveLink?: string,
+  menuButton___noActiveLink?: string,
   menuContainer?: string,
   menuNavLink?: string,
   menuNavLinkContainer?: string,
-  menuNavLinkContainer___active?: string
+  menuNavLinkContainer___active?: string,
+  menuNavLinkContainer___inActive?: string
 }
 
 const builtInCssClasses: NavigationCssClasses = {
   nav: 'border-b border-gray-200 text-gray-600 flex space-x-6 font-medium mb-6',
-  navLinkContainer: 'whitespace-nowrap py-3 mt-1 font-medium text-md border-b-2 border-opacity-0 hover:border-gray-300',
+  navLinkContainer: 'whitespace-nowrap py-3 mt-1 font-medium text-md border-b-2 hover:border-gray-300',
   navLink: 'py-3 px-2',
-  navLinkContainer___active: 'text-blue-600 border-blue-600 border-opacity-100 hover:border-blue-600',
+  navLinkContainer___active: 'text-blue-600 border-blue-600 hover:border-blue-600',
+  navLinkContainer___inActive: 'border-transparent',
   kebabIcon: 'pointer-events-none',
   menuButtonContainer: 'relative flex flex-grow justify-end mr-4',
-  menuButton: 'flex items-center text-gray-600 font-medium text-md h-12 mt-1 p-3 border-opacity-0 rounded-md hover:bg-gray-200',
-  menuButton___menuOpen: 'bg-gray-100 text-gray-800',
+  menuButton: 'flex items-center font-medium text-md h-12 mt-1 p-3 rounded-md hover:bg-gray-200',
+  menuButton___menuOpenNoActiveLink: 'bg-gray-100 text-gray-800',
+  menuButton___menuOpenHasActiveLink: 'bg-gray-100 text-blue-600',
   menuButton___hasActiveLink: 'text-blue-600',
+  menuButton___noActiveLink: 'text-gray-600',
   menuContainer: 'absolute flex-col bg-white border top-14 py-2 rounded-lg shadow-lg',
   menuNavLink: 'px-4 py-2 flex-grow',
-  menuNavLinkContainer: 'flex text-gray-600 hover:bg-gray-100 text-lg hover:text-gray-800 focus:text-gray-800',
-  menuNavLinkContainer___active: 'text-blue-600 hover:text-blue-600 focus:text-blue-600'
+  menuNavLinkContainer: 'flex hover:bg-gray-100 text-lg',
+  menuNavLinkContainer___active: 'text-blue-600 hover:text-blue-600 focus:text-blue-600',
+  menuNavLinkContainer___inActive: 'text-gray-600 hover:text-gray-800 focus:text-gray-800'
 }
 
 interface LinkData {
@@ -102,8 +110,10 @@ export default function Navigation({ links, customCssClasses, cssCompositionMeth
   const activeMenuLinkIndex = overflowLinks.findIndex(isActiveLink);
   const menuContainsActiveLink = activeMenuLinkIndex >= 0;
   const menuButtonClassNames = classNames(cssClasses.menuButton, {
-    [cssClasses.menuButton___menuOpen ?? '']: menuOpen,
-    [cssClasses.menuButton___hasActiveLink ?? '']: menuContainsActiveLink
+    [cssClasses.menuButton___menuOpenNoActiveLink ?? '']: menuOpen && !menuContainsActiveLink,
+    [cssClasses.menuButton___menuOpenHasActiveLink ?? '']: menuOpen && menuContainsActiveLink,
+    [cssClasses.menuButton___hasActiveLink ?? '']: !menuOpen && menuContainsActiveLink,
+    [cssClasses.menuButton___noActiveLink ?? '']: !menuOpen && !menuContainsActiveLink
   });
 
   return (
@@ -123,7 +133,8 @@ export default function Navigation({ links, customCssClasses, cssCompositionMeth
               {menuOpen && overflowLinks.map((l, index) => renderLink(l, query, index === activeMenuLinkIndex, {
                 navLink: cssClasses.menuNavLink,
                 navLinkContainer: cssClasses.menuNavLinkContainer,
-                navLinkContainer___active: cssClasses.menuNavLinkContainer___active
+                navLinkContainer___active: cssClasses.menuNavLinkContainer___active,
+                navLinkContainer___inActive: cssClasses.menuNavLinkContainer___inActive
               }))}
             </div>
           }
@@ -137,12 +148,19 @@ function renderLink(
   linkData: LinkData,
   query: string,
   isActiveLink: boolean,
-  cssClasses: { navLinkContainer?: string, navLinkContainer___active?: string, navLink?: string }) 
+  cssClasses: {
+    navLinkContainer?: string,
+    navLinkContainer___active?: string,
+    navLinkContainer___inActive?: string,
+    navLink?: string
+  }) 
 {
   const { to, label } = linkData;
   const navLinkContainerClasses = classNames(cssClasses.navLinkContainer, {
+    [cssClasses.navLinkContainer___inActive ?? '']: !isActiveLink,
     [cssClasses.navLinkContainer___active ?? '']: isActiveLink
   });
+
   return (
     <div className={navLinkContainerClasses} key={to}>
       <NavLink

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -18,8 +18,8 @@ interface NavigationCssClasses {
   menuButtonContainer?: string,
   menuButton___menuOpenNoActiveLink?: string,
   menuButton___menuOpenHasActiveLink?: string,
-  menuButton___hasActiveLink?: string,
-  menuButton___noActiveLink?: string,
+  menuButton___menuClosedHasActiveLink?: string,
+  menuButton___menuClosedNoActiveLink?: string,
   menuContainer?: string,
   menuNavLink?: string,
   menuNavLinkContainer?: string,
@@ -38,8 +38,8 @@ const builtInCssClasses: NavigationCssClasses = {
   menuButton: 'flex items-center font-medium text-md h-12 mt-1 p-3 rounded-md hover:bg-gray-200',
   menuButton___menuOpenNoActiveLink: 'bg-gray-100 text-gray-800',
   menuButton___menuOpenHasActiveLink: 'bg-gray-100 text-blue-600',
-  menuButton___hasActiveLink: 'text-blue-600',
-  menuButton___noActiveLink: 'text-gray-600',
+  menuButton___menuClosedHasActiveLink: 'text-blue-600',
+  menuButton___menuClosedNoActiveLink: 'text-gray-600',
   menuContainer: 'absolute flex-col bg-white border top-14 py-2 rounded-lg shadow-lg',
   menuNavLink: 'px-4 py-2 flex-grow',
   menuNavLinkContainer: 'flex hover:bg-gray-100 text-lg',
@@ -112,8 +112,8 @@ export default function Navigation({ links, customCssClasses, cssCompositionMeth
   const menuButtonClassNames = classNames(cssClasses.menuButton, {
     [cssClasses.menuButton___menuOpenNoActiveLink ?? '']: menuOpen && !menuContainsActiveLink,
     [cssClasses.menuButton___menuOpenHasActiveLink ?? '']: menuOpen && menuContainsActiveLink,
-    [cssClasses.menuButton___hasActiveLink ?? '']: !menuOpen && menuContainsActiveLink,
-    [cssClasses.menuButton___noActiveLink ?? '']: !menuOpen && !menuContainsActiveLink
+    [cssClasses.menuButton___menuClosedHasActiveLink ?? '']: !menuOpen && menuContainsActiveLink,
+    [cssClasses.menuButton___menuClosedNoActiveLink ?? '']: !menuOpen && !menuContainsActiveLink
   });
 
   return (


### PR DESCRIPTION
Upgrading tailwind from 2 to 3 introduced a number of styling regressions
due to a number of arguably breaking but undocumented changes.

It looks like tailwind has changed how it behaves when two tailwind classes modify
the same css attribute, for example having text-blue-600 and text-gray-800 on the same element.
The Navigation component was updated to no longer rely on this kind of behavior.

I did a quick audit to check that our other components don't rely on this behavior.

Tailwind also no longer supports `border-opacity` class, [you have to specify it as part of the border color](https://github.com/tailwindlabs/tailwindcss/discussions/7320#discussioncomment-2112053), despite not being mentioned as removed in the upgrade guide.

J=SLAP-1864
TEST=manual

test side by side with local site and a version of the react-site-search-starter
hosted on yext sites that doesn't have this styling regression

the navigation's menu button (which appears when the navigation tabs no longer fully
fit within the page's width) has correct styling for it's 4 different states

navigation tab styling outside of the menu have correct styling for both active, inactive, and hover
states