### PR TITLE
Fix VA styling

### DIFF
--- a/src/components/EntityPreviews.tsx
+++ b/src/components/EntityPreviews.tsx
@@ -5,7 +5,7 @@ import recursivelyMapChildren from './utils/recursivelyMapChildren';
 
 interface EntityPreviewsProps {
   verticalKey: string,
-  children: (results: Result[], showDivider?: boolean) => JSX.Element,
+  children: (results: Result[], index: number) => JSX.Element,
   limit?: number
 }
 
@@ -24,9 +24,9 @@ export default function EntityPreviews(_: EntityPreviewsProps) {
 /**
  * Recursively passes vertical results into instances of EntityPreview.
  */
-export function transformEntityPreviews(entityPreviews: JSX.Element, verticalResultsArray: VerticalResults[], showDivider?: boolean): ReactNode {
+export function transformEntityPreviews(entityPreviews: JSX.Element, verticalResultsArray: VerticalResults[]): ReactNode {
   const verticalKeyToResults = getVerticalKeyToResults(verticalResultsArray);
-  let hasEntityPreviews = false;
+  let index = 0;
   const renderedChildren = recursivelyMapChildren(entityPreviews, child => {
     if (!isValidElement(child) || child.type !== EntityPreviews) {
       return child;
@@ -35,10 +35,7 @@ export function transformEntityPreviews(entityPreviews: JSX.Element, verticalRes
     if (!(verticalKey in verticalKeyToResults)) {
       return null;
     }
-
-    const shouldShowDivider = hasEntityPreviews || showDivider;
-    hasEntityPreviews = true;
-    return children(verticalKeyToResults[verticalKey], shouldShowDivider);
+    return children(verticalKeyToResults[verticalKey], index++);
   });
   return renderedChildren;
 }

--- a/src/components/EntityPreviews.tsx
+++ b/src/components/EntityPreviews.tsx
@@ -5,7 +5,7 @@ import recursivelyMapChildren from './utils/recursivelyMapChildren';
 
 interface EntityPreviewsProps {
   verticalKey: string,
-  children: (results: Result[]) => JSX.Element,
+  children: (results: Result[], showDivider?: boolean) => JSX.Element,
   limit?: number
 }
 
@@ -24,8 +24,9 @@ export default function EntityPreviews(_: EntityPreviewsProps) {
 /**
  * Recursively passes vertical results into instances of EntityPreview.
  */
-export function transformEntityPreviews(entityPreviews: JSX.Element, verticalResultsArray: VerticalResults[]): ReactNode {
+export function transformEntityPreviews(entityPreviews: JSX.Element, verticalResultsArray: VerticalResults[], showDivider?: boolean): ReactNode {
   const verticalKeyToResults = getVerticalKeyToResults(verticalResultsArray);
+  let hasEntityPreviews = false;
   const renderedChildren = recursivelyMapChildren(entityPreviews, child => {
     if (!isValidElement(child) || child.type !== EntityPreviews) {
       return child;
@@ -34,7 +35,10 @@ export function transformEntityPreviews(entityPreviews: JSX.Element, verticalRes
     if (!(verticalKey in verticalKeyToResults)) {
       return null;
     }
-    return children(verticalKeyToResults[verticalKey]);
+
+    const shouldShowDivider = hasEntityPreviews || showDivider;
+    hasEntityPreviews = true;
+    return children(verticalKeyToResults[verticalKey], shouldShowDivider);
   });
   return renderedChildren;
 }

--- a/src/components/SampleVisualSearchBar.tsx
+++ b/src/components/SampleVisualSearchBar.tsx
@@ -16,11 +16,10 @@ export default function SampleVisualSearchBar() {
       placeholder='Search...'
       entityPreviewsDebouncingTime={100}
       verticalKeyToLabel={verticalKey => universalResultsConfig[verticalKey]?.label ?? verticalKey}
-      renderEntityPreviews={(isLoading, _results, onSubmit, showFirstDivider) => (
+      renderEntityPreviews={(isLoading, _results, onSubmit) => (
         <div className={isLoading ? 'opacity-50' : ''}>
           <EntityPreviews verticalKey='events'>
             {(results, _index) => (<>
-              {showFirstDivider && results.length > 0 && <div className='h-px bg-gray-200 mt-1 mb-4 mx-3.5'></div>}
               <div className='grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-4 mx-3.5 mt-1'>
                 {results.map((r, index) =>
                   <DropdownItem
@@ -40,7 +39,7 @@ export default function SampleVisualSearchBar() {
           </EntityPreviews>
           <EntityPreviews verticalKey='faqs' limit={2}>
             {(results, index) => (<>
-              {(showFirstDivider || index > 0) && results.length > 0 && <div className='h-px bg-gray-200 mt-1 mb-4 mx-3.5'></div>}
+              {index > 0 && results.length > 0 && <div className='h-px bg-gray-200 mt-1 mb-4 mx-3.5'></div>}
               <div className='flex flex-col'>
                 {results.map((r, index) =>
                   <DropdownItem

--- a/src/components/SampleVisualSearchBar.tsx
+++ b/src/components/SampleVisualSearchBar.tsx
@@ -19,8 +19,8 @@ export default function SampleVisualSearchBar() {
       renderEntityPreviews={(isLoading, _results, onSubmit) => (
         <div className={isLoading ? 'opacity-50' : ''}>
           <EntityPreviews verticalKey='events'>
-            {results => (<>
-              {results.length > 0 && <div className='h-px bg-gray-200 mt-1 mb-4 mx-3.5'></div>}
+            {(results, showDivider) => (<>
+              {showDivider && results.length > 0 && <div className='h-px bg-gray-200 mt-1 mb-4 mx-3.5'></div>}
               <div className='grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-4 mx-3.5 mt-1'>
                 {results.map((r, index) =>
                   <DropdownItem
@@ -39,7 +39,8 @@ export default function SampleVisualSearchBar() {
             )}
           </EntityPreviews>
           <EntityPreviews verticalKey='faqs' limit={2}>
-            {results => (
+            {(results, showDivider) => (<>
+              {showDivider && results.length > 0 && <div className='h-px bg-gray-200 mt-1 mb-4 mx-3.5'></div>}
               <div className='flex flex-col'>
                 {results.map((r, index) =>
                   <DropdownItem
@@ -54,6 +55,7 @@ export default function SampleVisualSearchBar() {
                   </DropdownItem>
                 )}
               </div>
+            </>
             )}
           </EntityPreviews>
         </div>
@@ -84,7 +86,6 @@ function FaqCard({ result }: CardProps) {
     : [];
 
   return (<div key={faqData.question}>
-    <div className='h-px bg-gray-200 mt-1 mb-4 mx-2.5'></div>
     <div tabIndex={0} className='flex flex-row mx-4 mb-3 rounded-md'>
       <FAQIcon className='w-6 mr-3 mt-1'/>
       <div>

--- a/src/components/SampleVisualSearchBar.tsx
+++ b/src/components/SampleVisualSearchBar.tsx
@@ -16,11 +16,11 @@ export default function SampleVisualSearchBar() {
       placeholder='Search...'
       entityPreviewsDebouncingTime={100}
       verticalKeyToLabel={verticalKey => universalResultsConfig[verticalKey]?.label ?? verticalKey}
-      renderEntityPreviews={(isLoading, _results, onSubmit) => (
+      renderEntityPreviews={(isLoading, _results, onSubmit, showFirstDivider) => (
         <div className={isLoading ? 'opacity-50' : ''}>
           <EntityPreviews verticalKey='events'>
-            {(results, showDivider) => (<>
-              {showDivider && results.length > 0 && <div className='h-px bg-gray-200 mt-1 mb-4 mx-3.5'></div>}
+            {(results, _index) => (<>
+              {showFirstDivider && results.length > 0 && <div className='h-px bg-gray-200 mt-1 mb-4 mx-3.5'></div>}
               <div className='grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-4 mx-3.5 mt-1'>
                 {results.map((r, index) =>
                   <DropdownItem
@@ -39,8 +39,8 @@ export default function SampleVisualSearchBar() {
             )}
           </EntityPreviews>
           <EntityPreviews verticalKey='faqs' limit={2}>
-            {(results, showDivider) => (<>
-              {showDivider && results.length > 0 && <div className='h-px bg-gray-200 mt-1 mb-4 mx-3.5'></div>}
+            {(results, index) => (<>
+              {(showFirstDivider || index > 0) && results.length > 0 && <div className='h-px bg-gray-200 mt-1 mb-4 mx-3.5'></div>}
               <div className='flex flex-col'>
                 {results.map((r, index) =>
                   <DropdownItem
@@ -51,6 +51,7 @@ export default function SampleVisualSearchBar() {
                     itemData={{ verticalLink: `/faqs?query=${r.name}` }}
                     onClick={onSubmit}
                   >
+                    {index > 0 && <div className='h-px bg-gray-200 mt-1 mb-4 mx-2.5'></div>}
                     <FaqCard result={r} key={`${index}-${r.name}`} />
                   </DropdownItem>
                 )}

--- a/src/components/SampleVisualSearchBar.tsx
+++ b/src/components/SampleVisualSearchBar.tsx
@@ -37,8 +37,7 @@ export default function SampleVisualSearchBar() {
             )}
           </EntityPreviews>
           <EntityPreviews verticalKey='faqs' limit={2}>
-            {(results, index) => (<>
-              {index > 0 && results.length > 0 && <div className='h-px bg-gray-200 mt-1 mb-4 mx-3.5'></div>}
+            {(results, verticalIndex) => (<>
               <div className='flex flex-col'>
                 {results.map((r, index) =>
                   <DropdownItem
@@ -49,7 +48,7 @@ export default function SampleVisualSearchBar() {
                     itemData={{ verticalLink: `/faqs?query=${r.name}` }}
                     onClick={onSubmit}
                   >
-                    {index > 0 && <div className='h-px bg-gray-200 mt-1 mb-4 mx-2.5'></div>}
+                    {(verticalIndex > 0 || index > 0) && <div className='h-px bg-gray-200 mt-1 mb-4 mx-3.5'></div>}
                     <FaqCard result={r} key={`${index}-${r.name}`} />
                   </DropdownItem>
                 )}

--- a/src/components/SampleVisualSearchBar.tsx
+++ b/src/components/SampleVisualSearchBar.tsx
@@ -19,7 +19,7 @@ export default function SampleVisualSearchBar() {
       renderEntityPreviews={(isLoading, _results, onSubmit) => (
         <div className={isLoading ? 'opacity-50' : ''}>
           <EntityPreviews verticalKey='events'>
-            {(results, _index) => (<>
+            {(results, _index) => (
               <div className='grid grid-cols-2 md:grid-cols-4 gap-x-6 gap-y-4 mx-3.5 mt-1'>
                 {results.map((r, index) =>
                   <DropdownItem
@@ -34,7 +34,6 @@ export default function SampleVisualSearchBar() {
                   </DropdownItem>
                 )}
               </div>
-            </>
             )}
           </EntityPreviews>
           <EntityPreviews verticalKey='faqs' limit={2}>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -30,7 +30,7 @@ import renderAutocompleteResult, {
 
 const builtInCssClasses: SearchBarCssClasses = {
   container: 'h-12 mb-3',
-  divider: 'border-t border-gray-200 mx-2.5',
+  inputDivider: 'border-t border-gray-200 mx-2.5',
   dropdownContainer: 'relative bg-white pt-4 pb-3 z-10',
   inputContainer: 'inline-flex items-center justify-between w-full',
   inputDropdownContainer: 'bg-white border rounded-3xl border-gray-200 w-full overflow-hidden',
@@ -48,6 +48,7 @@ const builtInCssClasses: SearchBarCssClasses = {
   recentSearchesOption: 'pl-3',
   recentSearchesNonHighlighted: 'font-normal', // Swap this to semibold once we apply highlighting to recent searches
   verticalLink: 'ml-12 pl-1 text-gray-500 italic',
+  entityPreviewsDivider: 'h-px bg-gray-200 mt-1 mb-4 mx-3.5',
   ...AutocompleteResultBuiltInCssClasses
 };
 
@@ -57,11 +58,11 @@ export interface SearchBarCssClasses extends AutocompleteResultCssClasses {
   inputContainer?: string,
   inputDropdownContainer?: string,
   inputDropdownContainer___active?: string,
+  inputDivider?: string,
   clearButton?: string,
   searchButton?: string,
   searchButtonContainer?: string,
   dropdownContainer?: string,
-  divider?: string,
   logoContainer?: string,
   optionContainer?: string,
   focusedOption?: string,
@@ -70,7 +71,8 @@ export interface SearchBarCssClasses extends AutocompleteResultCssClasses {
   recentSearchesOption?: string,
   recentSearchesNonHighlighted?: string,
   verticalLink?: string,
-  verticalDivider?: string
+  verticalDivider?: string,
+  entityPreviewsDivider?: string
 }
 
 type RenderEntityPreviews = (
@@ -294,7 +296,7 @@ export default function SearchBar({
           }
         }}
       >
-        <div className={cssClasses?.inputContainer}>
+        <div className={cssClasses.inputContainer}>
           <div className={cssClasses.logoContainer}>
             <YextLogoIcon />
           </div>
@@ -310,7 +312,7 @@ export default function SearchBar({
           <StyledDropdownMenu cssClasses={cssClasses}>
             {renderRecentSearches()}
             {renderQuerySuggestions()}
-            {showEntityPreviewsDivider && <div className='h-px bg-gray-200 mt-1 mb-4 mx-3.5'></div>}
+            {showEntityPreviewsDivider && <div className={cssClasses.entityPreviewsDivider}></div>}
             {transformedEntityPreviews}
           </StyledDropdownMenu>
         }
@@ -321,13 +323,13 @@ export default function SearchBar({
 
 function StyledDropdownMenu({ cssClasses, children }: PropsWithChildren<{
   cssClasses: {
-    divider?: string,
+    inputDivider?: string,
     dropdownContainer?: string
   }
 }>) {
   return (
     <DropdownMenu>
-      <div className={cssClasses.divider} />
+      <div className={cssClasses.inputDivider} />
       <div className={cssClasses.dropdownContainer}>
         {children}
       </div>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -64,7 +64,6 @@ export interface SearchBarCssClasses extends AutocompleteResultCssClasses {
   divider?: string,
   logoContainer?: string,
   optionContainer?: string,
-  optionIcon?: string,
   focusedOption?: string,
   recentSearchesOptionContainer?: string,
   recentSearchesIcon?: string,
@@ -227,7 +226,7 @@ export default function SearchBar({
         >
           {renderAutocompleteResult(
             result,
-            { ...cssClasses, icon: cssClasses.optionIcon },
+            cssClasses,
             MagnifyingGlassIcon,
             `autocomplete option: ${result.value}`
           )}
@@ -271,7 +270,8 @@ export default function SearchBar({
     );
   }
 
-  const transformedEntityPreviews = entityPreviews && transformEntityPreviews(entityPreviews, verticalResultsArray);
+  const showEntityPreviewDivider = !!(autocompleteResponse?.results.length || (!isVertical && filteredRecentSearches?.length));
+  const transformedEntityPreviews = entityPreviews && transformEntityPreviews(entityPreviews, verticalResultsArray, showEntityPreviewDivider);
   const entityPreviewsCount = calculateEntityPreviewsCount(transformedEntityPreviews);
   const hasItems = !!(autocompleteResponse?.results.length || (!isVertical && filteredRecentSearches?.length) || entityPreviewsCount);
   const screenReaderText = getScreenReaderText(autocompleteResponse?.results.length, filteredRecentSearches?.length, entityPreviewsCount);

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -76,8 +76,7 @@ export interface SearchBarCssClasses extends AutocompleteResultCssClasses {
 type RenderEntityPreviews = (
   autocompleteLoading: boolean,
   verticalResultsArray: VerticalResults[],
-  onSubmit: (value: string, _index: number, itemData?: FocusedItemData) => void,
-  showFirstDivider?: boolean
+  onSubmit: (value: string, _index: number, itemData?: FocusedItemData) => void
 ) => JSX.Element;
 
 interface Props {
@@ -157,8 +156,7 @@ export default function SearchBar({
 
   const [entityPreviewsState, executeEntityPreviewsQuery] = useEntityPreviews(entityPreviewsDebouncingTime);
   const { verticalResultsArray, isLoading: entityPreviewsLoading } = entityPreviewsState;
-  const showEntityPreviewsDivider = !!(autocompleteResponse?.results.length || (!isVertical && filteredRecentSearches?.length));
-  const entityPreviews = renderEntityPreviews && renderEntityPreviews(entityPreviewsLoading, verticalResultsArray, handleSubmit, showEntityPreviewsDivider);
+  const entityPreviews = renderEntityPreviews && renderEntityPreviews(entityPreviewsLoading, verticalResultsArray, handleSubmit);
   function updateEntityPreviews(query: string) {
     if (!renderEntityPreviews) {
       return;
@@ -274,6 +272,7 @@ export default function SearchBar({
 
   const transformedEntityPreviews = entityPreviews && transformEntityPreviews(entityPreviews, verticalResultsArray);
   const entityPreviewsCount = calculateEntityPreviewsCount(transformedEntityPreviews);
+  const showEntityPreviewsDivider = entityPreviewsCount > 0 && !!(autocompleteResponse?.results.length || (!isVertical && filteredRecentSearches?.length));
   const hasItems = !!(autocompleteResponse?.results.length || (!isVertical && filteredRecentSearches?.length) || entityPreviewsCount);
   const screenReaderText = getScreenReaderText(autocompleteResponse?.results.length, filteredRecentSearches?.length, entityPreviewsCount);
   const activeClassName = classNames(cssClasses.inputDropdownContainer, {
@@ -311,6 +310,7 @@ export default function SearchBar({
           <StyledDropdownMenu cssClasses={cssClasses}>
             {renderRecentSearches()}
             {renderQuerySuggestions()}
+            {showEntityPreviewsDivider && <div className='h-px bg-gray-200 mt-1 mb-4 mx-3.5'></div>}
             {transformedEntityPreviews}
           </StyledDropdownMenu>
         }

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -76,7 +76,8 @@ export interface SearchBarCssClasses extends AutocompleteResultCssClasses {
 type RenderEntityPreviews = (
   autocompleteLoading: boolean,
   verticalResultsArray: VerticalResults[],
-  onSubmit: (value: string, _index: number, itemData?: FocusedItemData) => void
+  onSubmit: (value: string, _index: number, itemData?: FocusedItemData) => void,
+  showFirstDivider?: boolean
 ) => JSX.Element;
 
 interface Props {
@@ -156,7 +157,8 @@ export default function SearchBar({
 
   const [entityPreviewsState, executeEntityPreviewsQuery] = useEntityPreviews(entityPreviewsDebouncingTime);
   const { verticalResultsArray, isLoading: entityPreviewsLoading } = entityPreviewsState;
-  const entityPreviews = renderEntityPreviews && renderEntityPreviews(entityPreviewsLoading, verticalResultsArray, handleSubmit);
+  const showEntityPreviewsDivider = !!(autocompleteResponse?.results.length || (!isVertical && filteredRecentSearches?.length));
+  const entityPreviews = renderEntityPreviews && renderEntityPreviews(entityPreviewsLoading, verticalResultsArray, handleSubmit, showEntityPreviewsDivider);
   function updateEntityPreviews(query: string) {
     if (!renderEntityPreviews) {
       return;
@@ -270,8 +272,7 @@ export default function SearchBar({
     );
   }
 
-  const showEntityPreviewDivider = !!(autocompleteResponse?.results.length || (!isVertical && filteredRecentSearches?.length));
-  const transformedEntityPreviews = entityPreviews && transformEntityPreviews(entityPreviews, verticalResultsArray, showEntityPreviewDivider);
+  const transformedEntityPreviews = entityPreviews && transformEntityPreviews(entityPreviews, verticalResultsArray);
   const entityPreviewsCount = calculateEntityPreviewsCount(transformedEntityPreviews);
   const hasItems = !!(autocompleteResponse?.results.length || (!isVertical && filteredRecentSearches?.length) || entityPreviewsCount);
   const screenReaderText = getScreenReaderText(autocompleteResponse?.results.length, filteredRecentSearches?.length, entityPreviewsCount);


### PR DESCRIPTION
Fix a styling regression where the magnifying glass icon for query suggestions in VA no longer appeared.

Also, fix the styling for entity previews when no other items are in the dropdown. In this case, the divider should not appear for the entity previews of the first vertical. But, if there are other verticals with entity previews, then these should have dividers.

J=SLAP-1861
TEST=manual

See that the icons for VA are correct and the divider above entity previews only appears over a vertical's preview cards if there are other dropdown items before it.