### PR TITLE
fix cta overflow css

### DIFF
--- a/src/components/cards/StandardCard.tsx
+++ b/src/components/cards/StandardCard.tsx
@@ -29,8 +29,8 @@ const builtInCssClasses: StandardCardCssClasses = {
   body: 'flex justify-end pt-2.5',
   descriptionContainer: 'w-full text-base',
   ctaContainer: 'flex flex-col justify-end ml-4',
-  cta1: 'min-w-max bg-blue-600 text-white font-medium rounded-lg py-2 px-5 shadow',
-  cta2: 'min-w-max bg-white text-blue-600 font-medium rounded-lg py-2 px-5 mt-2 shadow',
+  cta1: 'whitespace-nowrap bg-blue-600 text-white font-medium rounded-lg py-2 px-5 shadow',
+  cta2: 'whitespace-nowrap bg-white text-blue-600 font-medium rounded-lg py-2 px-5 mt-2 shadow',
   ordinal: 'mr-1.5 text-lg font-medium',
   title: 'text-lg font-medium'
 }


### PR DESCRIPTION
tailwindcss classname `min-w-max` uses `min-width: max-content` property. There's [browser support issues ](https://caniuse.com/?search=max-content)in safari and firefox with `max-content` properties (I believe it's specifically in flex items/with flex-basis).  This pr update the card component to use `whitespace: nowrap` instead which would also ensure the same behavior, having the button's text all in one line.

Checked universal/vertical searchbar in firefox and confirmed that icons have normal sizes.

J=SLAP-1867
TEST=manual

See that CTA buttons no longer overflow in chrome, firefox, and safari.