### PR TITLE
Use reusable workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,25 +9,10 @@ on:
   pull_request:
 
 jobs:
-  Coveralls:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js 16.x
-      uses: actions/setup-node@v2
-      with:
-        node-version: 16.x
-        registry-url: 'https://registry.npmjs.org'
-    # Skip post-install scripts here, as a malicious
-    # script could steal the NPM_TOKEN.
-    - run: npm ci --ignore-scripts
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-    # `npm rebuild` will run all those post-install scripts for us.
-    - run: npm rebuild
-    - run: npm test -- --coverage
-    - name: Coveralls
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+  call_code_coverage:
+    uses: yext/slapshot-reusable-workflows/.github/workflows/coverage.yml@v1
+    with:
+      test_script: npm test -- --coverage
+    secrets:
+      caller_github_token: ${{ secrets.GITHUB_TOKEN }}
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,26 +6,7 @@ name: Run Tests
 on: [push, pull_request]
 
 jobs:
-  tests:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [12.x, 14.x, 16.x]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-        registry-url: 'https://registry.npmjs.org'
-    # Skip post-install scripts here, as a malicious
-    # script could steal the NPM_TOKEN.
-    - run: npm ci --ignore-scripts
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-    # `npm rebuild` will run all those post-install scripts for us.
-    - run: npm rebuild
-    - run: npm run build
-    - run: npm test
+  call_run_tests:
+    uses:  yext/slapshot-reusable-workflows/.github/workflows/run_tests.yml@v1
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/third_party_notices_check.yml
+++ b/.github/workflows/third_party_notices_check.yml
@@ -3,26 +3,9 @@ name: Check Third Party Notices File
 on: pull_request
 
 jobs:
-  license-check:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 16.x
-          registry-url: 'https://registry.npmjs.org'
-      - uses: actions/checkout@v2
-      # Skip post-install scripts here, as a malicious
-      # script could steal the NPM_TOKEN.
-      - run: npm ci --ignore-scripts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      # `npm rebuild` will run all those post-install scripts for us.
-      - run: npm rebuild
-      - run: npm run generate-notices
-      - name: Update THIRD-PARTY-NOTICES
-        uses: EndBug/add-and-commit@v7
-        with:
-          message: "Automated update to THIRD-PARTY-NOTICES from github action's 3rd party notices check"
-          add: 'THIRD-PARTY-NOTICES'
-          push: true
-          default_author: github_actions
+  call_notices_check:
+    uses:  yext/slapshot-reusable-workflows/.github/workflows/third_party_notices_check.yml@v1
+    with:
+      environment: macos-latest
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/wcag_test.yml
+++ b/.github/workflows/wcag_test.yml
@@ -5,26 +5,7 @@ on:
     branches: [main, develop, hotfix/*, release/*, support/*]
 
 jobs:
-  WCAG-test:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [15.x]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-        registry-url: 'https://registry.npmjs.org'
-    # Skip post-install scripts here, as a malicious
-    # script could steal the NPM_TOKEN.
-    - run: npm ci --ignore-scripts
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-    # `npm rebuild` will run all those post-install scripts for us.
-    - run: npm rebuild
-    - run: npm run build
-    - run: npm run wcag
+  call_wcag_test:
+    uses: yext/slapshot-reusable-workflows/.github/workflows/wcag_test.yml@v1
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Update the github workflows to use the callable workflows in the `slapshot-reusable-workflows` repo.

J=SLAP-2005
TEST=auto

- See that all four workflows run on this PR as expected.
- Test on another branch (`dev/test-reusable-workflows`) and see that third party notices are updated when needed.